### PR TITLE
Keep source visible when group has single source

### DIFF
--- a/src/handlers/channel_photo.rs
+++ b/src/handlers/channel_photo.rs
@@ -1,10 +1,11 @@
 use anyhow::Context;
 use async_trait::async_trait;
+use redis::AsyncCommands;
 use tgbotapi::{requests::*, *};
 
 use super::Status::*;
 use crate::needs_field;
-use crate::utils::{extract_links, get_matches, get_message, link_was_seen};
+use crate::utils::{extract_links, find_best_photo, get_message, link_was_seen, match_image};
 
 pub struct ChannelPhotoHandler;
 
@@ -42,19 +43,18 @@ impl super::Handler for ChannelPhotoHandler {
             return Ok(Completed);
         }
 
-        let matches = get_matches(&handler.bot, &handler.fapi, &handler.conn, &sizes)
+        let file = find_best_photo(&sizes).unwrap();
+        let mut matches = match_image(&handler.bot, &handler.conn, &handler.fapi, &file)
             .await
             .context("unable to get matches")?;
 
-        let first = match matches {
+        // Only keep matches with a distance of 3 or less
+        matches.retain(|m| m.distance.unwrap() <= 3);
+
+        let first = match matches.first() {
             Some(first) => first,
             _ => return Ok(Completed),
         };
-
-        // Ignore unlikely matches
-        if first.distance.unwrap() > 3 {
-            return Ok(Completed);
-        }
 
         let sites = handler.sites.lock().await;
 
@@ -64,6 +64,45 @@ impl super::Handler for ChannelPhotoHandler {
         }
 
         drop(sites);
+
+        // Telegram only shows a caption on a media group if there is a single
+        // caption anywhere in the group. When users upload a group, we need
+        // to check if we can only set a single source to make the link more
+        // visible. This can be done by ensuring our source has been previouly
+        // used in the media group.
+        //
+        // For our implementation, this is done by maintaining a Redis set of
+        // every source previously displayed. If adding our source links returns
+        // fewer inserted than we had, it means a link was previously used and
+        // therefore we do not have to set a source.
+        //
+        // Because Telegram doesn't send media groups at once, we have to store
+        // these values until we're sure the group is over. In this case, we
+        // will store values for 300 seconds.
+        //
+        // No link normalization is required here because all links are already
+        // normalized when coming from FuzzySearch.
+        if let Some(group_id) = &message.media_group_id {
+            let key = format!("group-sources:{}", group_id);
+
+            let mut urls = matches.iter().map(|m| m.url()).collect::<Vec<_>>();
+            urls.sort();
+            urls.dedup();
+            let source_count = urls.len();
+
+            let mut conn = handler.redis.clone();
+            let added_links: usize = conn.sadd(&key, urls).await?;
+            conn.expire(&key, 300).await?;
+
+            if source_count > added_links {
+                tracing::debug!(
+                    source_count,
+                    added_links,
+                    "media group already contained source"
+                );
+                return Ok(Completed);
+            }
+        }
 
         // If this photo was part of a media group, we should set a caption on
         // the image because we can't make an inline keyboard on it.
@@ -113,9 +152,9 @@ impl super::Handler for ChannelPhotoHandler {
             // I'm not sure if there's any way to detect this before processing
             // an update, so ignore these errors.
             Err(tgbotapi::Error::Telegram(tgbotapi::TelegramError {
-                error_code: Some(code),
+                error_code: Some(400),
                 ..
-            })) if code == 400 => Ok(Completed),
+            })) => Ok(Completed),
             Ok(_) => Ok(Completed),
             Err(e) => Err(e).context("unable to update channel message"),
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -615,18 +615,6 @@ pub fn link_was_seen(
     )
 }
 
-pub async fn get_matches(
-    bot: &tgbotapi::Telegram,
-    fapi: &fuzzysearch::FuzzySearch,
-    conn: &sqlx::Pool<sqlx::Postgres>,
-    sizes: &[tgbotapi::PhotoSize],
-) -> anyhow::Result<Option<fuzzysearch::File>> {
-    // Find the highest resolution size of the image and download.
-    let best_photo = find_best_photo(&sizes).unwrap();
-    let matches = match_image(&bot, &conn, &fapi, &best_photo).await?;
-    Ok(matches.into_iter().next())
-}
-
 pub fn user_from_update(update: &tgbotapi::Update) -> Option<&tgbotapi::User> {
     use tgbotapi::*;
 


### PR DESCRIPTION
This changes the channel source behavior to only include a single source in media groups, if possible.

It keeps track of all the source URLs in an expiring Redis set, and if sources had previously been seen in that media group, it ignores the item.