### PR TITLE
Resize large inline image results

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ Env Name                   | Description
 `S3_BUCKET`                | S3 bucket
 `S3_URL`                   | URL to use for generating path to file in S3 bucket
 `FAUTIL_APITOKEN`          | API Token for [fuzzysearch.net](https://fuzzysearch.net)
-`SIZE_IMAGES`              | Optional, download and send image size to Telegram (highly suggested, fixes a bug)
-`CACHE_IMAGES`             | Optional, download and cache images to use with Telegram
+`CACHE_ALL_IMAGES`         | Optional, download and cache all inline images
 `METRICS_HOST`             | Host to expose Prometheus metrics, health check
 `DB_HOST`                  | Host for PostgreSQL database
 `DB_USER`                  | User for PostgreSQL database

--- a/src/handlers/inline_handler.rs
+++ b/src/handlers/inline_handler.rs
@@ -8,6 +8,9 @@ use anyhow::Context;
 use async_trait::async_trait;
 use tgbotapi::{requests::*, *};
 
+/// Telegram allows inline results up to 5MB.
+static MAX_IMAGE_SIZE: usize = 5_000_000;
+
 pub struct InlineHandler;
 
 #[derive(PartialEq)]
@@ -370,10 +373,17 @@ async fn build_image_result(
     let mut result = result.to_owned();
     result.thumb = Some(thumb_url);
 
-    // Check if we should cache images, top priority option. If not, check if
-    // we should size them (this should probably always be true). And finally,
-    // if no other options are set we should pass the result through untouched.
-    let result = if handler.config.cache_images.unwrap_or(false) {
+    // There is a bit of processing required to figure out how to handle an
+    // image before sending it off to Telegram. First, we check if the config
+    // specifies we should cache (re-upload) all images to the S3 bucket. If
+    // enabled, this is all we have to do. Otherwise, we need to download the
+    // image to make sure that it is below Telegram's 5MB image limit. This also
+    // allows us to calculate an image height and width to resolve a bug in
+    // Telegram Desktop[^1]. This currently has a worst case of downloading an
+    // image twice if it is above the maximum size.
+    //
+    // [^1]: https://github.com/telegramdesktop/tdesktop/issues/4580
+    let result = if handler.config.cache_all_images.unwrap_or(false) {
         cache_post(
             &handler.conn,
             &handler.s3,
@@ -382,10 +392,21 @@ async fn build_image_result(
             &result,
         )
         .await?
-    } else if handler.config.size_images.unwrap_or(false) {
-        size_post(&result).await?
     } else {
-        result
+        let result = size_post(&result).await?;
+
+        if result.image_size.unwrap_or_default() > MAX_IMAGE_SIZE {
+            cache_post(
+                &handler.conn,
+                &handler.s3,
+                &handler.config.s3_bucket,
+                &handler.config.s3_url,
+                &result,
+            )
+            .await?
+        } else {
+            result
+        }
     };
 
     let mut photo = InlineQueryResult::photo(

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,8 +94,7 @@ pub struct Config {
 
     pub fautil_apitoken: String,
 
-    pub size_images: Option<bool>,
-    pub cache_images: Option<bool>,
+    pub cache_all_images: Option<bool>,
 
     redis_dsn: String,
 

--- a/src/sites.rs
+++ b/src/sites.rs
@@ -34,6 +34,8 @@ pub struct PostInfo {
     pub site_name: &'static str,
     /// Width and height of image, if available
     pub image_dimensions: Option<(u32, u32)>,
+    /// Size of image in bytes, if available
+    pub image_size: Option<usize>,
 }
 
 fn get_file_ext(name: &str) -> Option<&str> {
@@ -452,7 +454,7 @@ impl Site for Twitter {
                         title: Some(user.screen_name.clone()),
                         extra_caption: Some(text.clone()),
                         site_name: self.name(),
-                        image_dimensions: None,
+                        ..Default::default()
                     },
                     None => PostInfo {
                         file_type: get_file_ext(&item.media_url_https).unwrap().to_owned(),


### PR DESCRIPTION
Partially addresses #39 by resizing inline image results larger than 5MB. It reuses the existing code for caching images.

Still needing to be addressed:
- [x] Large images are downloaded twice, once to get the size then once to resize and re-upload 
- [x] JPEGs are not resized due to previous handling of caching code