### PR TITLE
Always use site name inline to improve caching

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -519,18 +519,6 @@ pub async fn sort_results(
     Ok(())
 }
 
-pub async fn use_source_name(
-    conn: &sqlx::Pool<sqlx::Postgres>,
-    user_id: i32,
-) -> anyhow::Result<bool> {
-    let row = UserConfig::get(&conn, UserConfigKey::SourceName, user_id)
-        .await
-        .context("unable to query user source name config")?
-        .unwrap_or(false);
-
-    Ok(row)
-}
-
 /// Extract all possible links from a Message. It looks at the text,
 /// caption, and all buttons within an inline keyboard. Uses URL parsing from
 /// Telegram.


### PR DESCRIPTION
There was a setting to toggle between showing a generic 'Source' button or the site name in inline results, but this prevents us from allowing Telegram to cache results. This removes that feature and only shows the site name as a source link.