### PR TITLE
Check URLs before assuming they are not valid sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,6 +766,8 @@ dependencies = [
  "foxbot-sites",
  "foxbot-utils",
  "fuzzysearch",
+ "hamming",
+ "image",
  "redis",
  "serde",
  "serde_json",

--- a/foxbot-channel-worker/Cargo.toml
+++ b/foxbot-channel-worker/Cargo.toml
@@ -24,6 +24,9 @@ chrono = "0.4"
 tokio = "1"
 redis = { version = "0.20", features = ["connection-manager", "tokio-comp"] }
 
+image = "0.23"
+hamming = "0.1"
+
 tgbotapi = { git = "https://github.com/Syfaro/tgbotapi-rs" }
 fuzzysearch = { git = "https://github.com/Syfaro/fuzzysearch-rs", features = ["trace", "local_hash"] }
 

--- a/foxbot-channel-worker/src/main.rs
+++ b/foxbot-channel-worker/src/main.rs
@@ -7,6 +7,7 @@ use tgbotapi::{
     requests::{EditMessageCaption, EditMessageReplyMarkup, ReplyMarkup},
     InlineKeyboardButton, InlineKeyboardMarkup,
 };
+use tracing::Instrument;
 
 use foxbot_sites::BoxedSite;
 use foxbot_utils::*;
@@ -243,9 +244,9 @@ impl Handler {
         .context("Unable to get matches")?;
 
         // Only keep matches with a distance of 3 or less
-        matches.retain(|m| m.distance.unwrap() <= 3);
+        matches.1.retain(|m| m.distance.unwrap() <= 3);
 
-        let first = match matches.first() {
+        let first = match matches.1.first() {
             Some(first) => first,
             _ => {
                 tracing::debug!("Unable to find sources for image");
@@ -254,21 +255,42 @@ impl Handler {
             }
         };
 
-        let sites = self.sites.lock().await;
+        let links = extract_links(&message);
+
+        let mut sites = self.sites.lock().await;
 
         // If any matches contained a link we found in the message, skip adding
         // a source.
         if matches
+            .1
             .iter()
-            .any(|file| link_was_seen(&sites, &extract_links(&message), &file.url()))
+            .any(|file| link_was_seen(&sites, &links, &file.url()))
         {
             tracing::trace!("Post already contained valid source URL");
             return Ok(());
         }
 
+        if !links.is_empty() {
+            let mut results: Vec<foxbot_sites::PostInfo> = Vec::new();
+            let _ = find_images(&tgbotapi::User::default(), links, &mut sites, &mut |info| {
+                results.extend(info.results);
+            })
+            .await;
+
+            let urls: Vec<_> = results
+                .iter()
+                .map::<&str, _>(|result| &result.url)
+                .collect();
+            if has_similar_hash(matches.0, &urls).await {
+                tracing::debug!("URL in post contained similar hash");
+
+                return Ok(());
+            }
+        }
+
         drop(sites);
 
-        if already_had_source(&self.redis, &message, &matches).await? {
+        if already_had_source(&self.redis, &message, &matches.1).await? {
             tracing::trace!("Post group already contained source URL");
             return Ok(());
         }
@@ -444,6 +466,61 @@ async fn already_had_source(
     );
 
     Ok(source_count > added_links)
+}
+
+/// Check if any of the provided image URLs have a hash similar to the given
+/// input.
+#[tracing::instrument(skip(urls))]
+async fn has_similar_hash(to: i64, urls: &[&str]) -> bool {
+    let to = to.to_be_bytes();
+
+    for url in urls {
+        let check_size = CheckFileSize::new(url, 50_000_000);
+        let bytes = match check_size.into_bytes().await {
+            Ok(bytes) => bytes,
+            Err(err) => {
+                tracing::warn!("Unable to download image: {:?}", err);
+
+                continue;
+            }
+        };
+
+        let hash = tokio::task::spawn_blocking(move || {
+            use std::convert::TryInto;
+
+            let hasher = fuzzysearch::get_hasher();
+
+            let im = match image::load_from_memory(&bytes) {
+                Ok(im) => im,
+                Err(err) => {
+                    tracing::warn!("Unable to load image: {:?}", err);
+
+                    return None;
+                }
+            };
+
+            let hash = hasher.hash_image(&im);
+            let bytes: [u8; 8] = hash.as_bytes().try_into().unwrap_or_default();
+
+            Some(bytes)
+        })
+        .in_current_span()
+        .await
+        .unwrap_or_default();
+
+        let hash = match hash {
+            Some(hash) => hash,
+            _ => continue,
+        };
+
+        if hamming::distance_fast(&to, &hash).unwrap() <= 3 {
+            tracing::debug!(url, hash = i64::from_be_bytes(hash), "Hashes were similar");
+
+            return true;
+        }
+    }
+
+    false
 }
 
 #[cfg(test)]

--- a/foxbot/src/handlers/commands.rs
+++ b/foxbot/src/handlers/commands.rs
@@ -323,7 +323,8 @@ impl CommandHandler {
             &best_photo,
             Some(3),
         )
-        .await?;
+        .await?
+        .1;
         sort_results(
             &handler.conn,
             message.from.as_ref().unwrap().id,
@@ -390,6 +391,7 @@ impl CommandHandler {
                     Some(10),
                 )
                 .await?
+                .1
             }
             None => {
                 let links = extract_links(&message);

--- a/foxbot/src/handlers/group_source.rs
+++ b/foxbot/src/handlers/group_source.rs
@@ -59,7 +59,8 @@ impl Handler for GroupSourceHandler {
             &best_photo,
             Some(3),
         )
-        .await?;
+        .await?
+        .1;
         sort_results(
             &handler.conn,
             message.from.as_ref().unwrap().id,

--- a/foxbot/src/handlers/photo.rs
+++ b/foxbot/src/handlers/photo.rs
@@ -47,7 +47,8 @@ impl Handler for PhotoHandler {
             &best_photo,
             Some(3),
         )
-        .await?;
+        .await?
+        .1;
         sort_results(
             &handler.conn,
             message.from.as_ref().unwrap().id,


### PR DESCRIPTION
Currently, if a user provides a source link that FuzzySearch doesn't know about (Mastodon, Twitter link before it's indexed, etc.) the bot will add a new source link to the post. This change has the bot check all URLs in a post to see if they could be considered a valid source using known sites. 

Closes #65.