### PR TITLE
Allow sites to return displayable error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,15 +25,9 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "ahash"
-version = "0.4.7"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
-
-[[package]]
-name = "ahash"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f200cbb1e856866d9eade941cf3aa0c5d7dd36f74311c4273b494f4ef036957"
+checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
 dependencies = [
  "getrandom 0.2.3",
  "once_cell",
@@ -66,9 +60,9 @@ checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
 name = "arc-swap"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d7d63395147b81a9e570bcc6243aaf71c017bd666d4909cfef0085bdda8d73"
+checksum = "e906254e445520903e7fc9da4f709886c84ae4bc4ddaf0e093188d66df4dc820"
 
 [[package]]
 name = "arrayvec"
@@ -227,9 +221,9 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cc"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 
 [[package]]
 name = "cfg-if"
@@ -818,6 +812,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tgbotapi",
+ "thiserror",
 ]
 
 [[package]]
@@ -1125,17 +1120,23 @@ name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash 0.4.7",
+ "ahash",
 ]
 
 [[package]]
 name = "hashlink"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d99cf782f0dc4372d26846bec3de7804ceb5df083c2d4462c0b8d2330e894fa8"
+checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -1233,15 +1234,15 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "httpdate"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05842d0d43232b23ccb7060ecb0f0626922c21f30012e97b767b30afd4a5d4b9"
+checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "hyper"
-version = "0.14.7"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e5f105c494081baa3bf9e200b279e27ec1623895cd504c7dbef8d0b080fcf54"
+checksum = "d3f71a7eea53a3f8257a7b4795373ff886397178cd634430ea94e12d7fe4fe34"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1251,7 +1252,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
- "httpdate 1.0.0",
+ "httpdate 1.0.1",
  "itoa",
  "pin-project",
  "socket2",
@@ -1324,7 +1325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.9.1",
 ]
 
 [[package]]
@@ -1413,9 +1414,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
 
 [[package]]
 name = "linkify"
@@ -2885,9 +2886,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.5.2"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d582b9bc04ec6c03084196efc42c2226b018e9941f03ee62bd88921d500917c0"
+checksum = "ba82f79b31f30acebf19905bcd8b978f46891b9d0723f578447361a8910b6584"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -2895,11 +2896,11 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.5.2"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de52d1d473cebb2abb79c886ef6a8023e965e34c0676a99cfeac2cc7f0fde4c1"
+checksum = "7f23af36748ec8ea8d49ef8499839907be41b0b1178a4e82b8cb45d29f531dc9"
 dependencies = [
- "ahash 0.7.2",
+ "ahash",
  "atoi",
  "base64",
  "bitflags",
@@ -2946,9 +2947,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.5.2"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a40f0be97e704d3fbf059e7e3333c3735639146a72d586c5534c70e79da88a4"
+checksum = "47e4a2349d1ffd60a03ca0de3f116ba55d7f406e55a0d84c64a5590866d94c06"
 dependencies = [
  "dotenv",
  "either",
@@ -2969,9 +2970,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-rt"
-version = "0.5.2"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6ae97ab05063ed515cdc23d90253213aa24dda0a288c5ec079af3d10f9771bc"
+checksum = "8199b421ecf3493ee9ef3e7bc90c904844cfb2ea7ea2f57347a93f52bfd3e057"
 dependencies = [
  "once_cell",
  "tokio",
@@ -3170,18 +3171,18 @@ checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3638,9 +3639,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d"
+checksum = "025ce40a007e1907e58d5bc1a594def78e5573bb0b1160bc389634e8f12e4faa"
 
 [[package]]
 name = "version_check"

--- a/foxbot-models/Cargo.toml
+++ b/foxbot-models/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
+thiserror = "1"
+
 prometheus = "0.12"
 chrono = "0.4"
 

--- a/foxbot-models/src/lib.rs
+++ b/foxbot-models/src/lib.rs
@@ -4,6 +4,30 @@ lazy_static::lazy_static! {
     static ref CACHE_REQUESTS: prometheus::CounterVec = prometheus::register_counter_vec!("foxbot_cache_requests_total", "Number of file cache hits and misses", &["result"]).unwrap();
 }
 
+/// An error message that is safe to be displayed to the user.
+///
+/// This should not contain any technical or internal information.
+#[derive(thiserror::Error, Debug)]
+#[error("{msg}")]
+pub struct DisplayableErrorMessage<'a> {
+    pub msg: std::borrow::Cow<'a, str>,
+    #[source]
+    source: anyhow::Error,
+}
+
+impl<'a> DisplayableErrorMessage<'a> {
+    pub fn new<M, E>(msg: M, err: E) -> Self
+    where
+        M: Into<std::borrow::Cow<'a, str>>,
+        E: Into<anyhow::Error>,
+    {
+        DisplayableErrorMessage {
+            msg: msg.into(),
+            source: err.into(),
+        }
+    }
+}
+
 /// Each available site, for configuration usage.
 #[derive(Clone, Debug, PartialEq, Hash, Eq, serde::Deserialize)]
 pub enum Sites {

--- a/foxbot-utils/src/lib.rs
+++ b/foxbot-utils/src/lib.rs
@@ -88,10 +88,7 @@ where
             if site.url_supported(link).await {
                 tracing::debug!(link, site = site.name(), "found supported link");
 
-                let images = site
-                    .get_images(user.id, link)
-                    .await
-                    .context("unable to extract site images")?;
+                let images = site.get_images(user.id, link).await?;
 
                 match images {
                     Some(results) => {
@@ -334,9 +331,14 @@ pub fn add_sentry_tracing(scope: &mut sentry::Scope) {
 type SentryTags<'a> = Option<Vec<(&'a str, String)>>;
 
 /// Run a callback within a Sentry scope with a given user and tags.
-pub fn with_user_scope<C, R>(from: Option<&tgbotapi::User>, tags: SentryTags, callback: C) -> R
+pub fn with_user_scope<C, R>(
+    from: Option<&tgbotapi::User>,
+    err: &anyhow::Error,
+    tags: SentryTags,
+    callback: C,
+) -> R
 where
-    C: FnOnce() -> R,
+    C: FnOnce(&anyhow::Error) -> R,
 {
     tracing::trace!(?tags, ?from, "updating sentry scope");
 
@@ -358,7 +360,7 @@ where
                 }
             }
         },
-        callback,
+        || callback(err),
     )
 }
 
@@ -469,8 +471,8 @@ pub fn continuous_action(
                     .for_each(|_| async {
                         if let Err(e) = bot.make_request(&chat_action).await {
                             tracing::warn!("unable to send chat action: {:?}", e);
-                            with_user_scope(user.as_ref(), None, || {
-                                sentry::capture_error(&e);
+                            with_user_scope(user.as_ref(), &e.into(), None, |err| {
+                                sentry::integrations::anyhow::capture_anyhow(&err);
                             });
                         }
                     }),

--- a/langs/en-US/foxbot.ftl
+++ b/langs/en-US/foxbot.ftl
@@ -109,8 +109,16 @@ automatic-preview-enable = Sourced image previews enabled.
 
 # Error Messages
 error-generic = Oh no, something went wrong! Please send a message to my creator, { -creatorName }, saying what happened.
+error-generic-message =
+    Oh no, something went wrong: { $message }
+    
+    Please send a message to my creator, { -creatorName }, saying what happened.
 error-generic-count = Oh no, something went wrong! I've encountered { $count } errors. Please send a message to my creator, { -creatorName }, saying what happened.
 error-uuid = Oh no, something went wrong! Please reply to this message saying what happened. You may also send a message to my creator, { -creatorName }, with this ID if you continue having issues: { $uuid }
+error-uuid-message =
+    Oh no, something went wrong: { $message }
+    
+    Please reply to this message saying what happened. You may also send a message to my creator, { -creatorName }, with this ID if you continue having issues: { $uuid }
 error-uuid-count = Oh no, something went wrong! I've encountered { $count } errors. Please reply to this message saying what happened. You may also send a message to my creator, { -creatorName }, with this ID if you continue having issues: { $uuid }
 error-feedback = Thank you for the feedback, hopefully we can get this issue resolved soon.
 error-delete-callback = Error retrieving message to delete 


### PR DESCRIPTION
Rework error handling to have displayable error messages. Closes #56. 

If a site returns a `DisplayableErrorMessage`, the message contents are returned as an inline result or as part of the error message.