### PR TITLE
Consolidate automatic media group sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,91 +4,69 @@ version = 3
 
 [[package]]
 name = "actix-codec"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78d1833b3838dbe990df0f1f87baf640cf6146e898166afe401839d1b001e570"
+checksum = "1d5dbeb2d9e51344cb83ca7cc170f1217f9fe25bfc50160e6e200b5c31c1019a"
 dependencies = [
  "bitflags",
- "bytes 0.5.6",
+ "bytes",
  "futures-core",
  "futures-sink",
  "log",
- "pin-project 0.4.28",
- "tokio 0.2.25",
- "tokio-util 0.3.1",
-]
-
-[[package]]
-name = "actix-connect"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177837a10863f15ba8d3ae3ec12fac1099099529ed20083a27fdfe247381d0dc"
-dependencies = [
- "actix-codec",
- "actix-rt",
- "actix-service",
- "actix-utils",
- "derive_more",
- "either",
- "futures-util",
- "http",
- "log",
- "trust-dns-proto",
- "trust-dns-resolver",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
 name = "actix-http"
-version = "2.2.0"
+version = "3.0.0-beta.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "452299e87817ae5673910e53c243484ca38be3828db819b6011736fc6982e874"
+checksum = "59d51c2ba06062e698a5d212d860e9fb2afc931c285ede687aaae896c8150347"
 dependencies = [
  "actix-codec",
- "actix-connect",
  "actix-rt",
  "actix-service",
- "actix-threadpool",
+ "actix-tls",
  "actix-utils",
+ "ahash",
  "base64",
  "bitflags",
  "brotli2",
- "bytes 0.5.6",
- "cookie",
- "copyless",
+ "bytes",
+ "bytestring",
  "derive_more",
- "either",
  "encoding_rs",
  "flate2",
- "futures-channel",
  "futures-core",
  "futures-util",
- "fxhash",
- "h2 0.2.7",
+ "h2",
  "http",
  "httparse",
- "indexmap",
  "itoa",
  "language-tags",
- "lazy_static",
+ "local-channel",
  "log",
  "mime",
+ "once_cell",
+ "paste",
  "percent-encoding",
- "pin-project 1.0.7",
- "rand 0.7.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.3",
  "regex",
  "serde",
- "serde_json",
- "serde_urlencoded",
  "sha-1 0.9.6",
- "slab",
+ "smallvec",
  "time 0.2.26",
+ "tokio",
 ]
 
 [[package]]
 name = "actix-macros"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ca8ce00b267af8ccebbd647de0d61e0674b6e61185cc7a592ff88772bed655"
+checksum = "dbcb2b608f0accc2f5bcf3dd872194ce13d94ee45b571487035864cf966b04ef"
 dependencies = [
  "quote",
  "syn",
@@ -109,115 +87,75 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
-version = "1.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143fcc2912e0d1de2bcf4e2f720d2a60c28652ab4179685a1ee159e0fb3db227"
+checksum = "bc7d7cd957c9ed92288a7c3c96af81fa5291f65247a76a34dac7b6af74e52ba0"
 dependencies = [
  "actix-macros",
- "actix-threadpool",
- "copyless",
- "futures-channel",
- "futures-util",
- "smallvec",
- "tokio 0.2.25",
+ "futures-core",
+ "tokio",
 ]
 
 [[package]]
 name = "actix-server"
-version = "1.0.4"
+version = "2.0.0-beta.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45407e6e672ca24784baa667c5d32ef109ccdd8d5e0b5ebb9ef8a67f4dfb708e"
+checksum = "26369215fcc3b0176018b3b68756a8bcc275bb000e6212e454944913a1f9bf87"
 dependencies = [
- "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-utils",
- "futures-channel",
- "futures-util",
+ "futures-core",
  "log",
- "mio 0.6.23",
- "mio-uds",
+ "mio",
  "num_cpus",
  "slab",
- "socket2 0.3.19",
+ "tokio",
 ]
 
 [[package]]
 name = "actix-service"
-version = "1.0.6"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0052435d581b5be835d11f4eb3bce417c8af18d87ddf8ace99f8e67e595882bb"
+checksum = "77f5f9d66a8730d0fae62c26f3424f5751e5518086628a40b7ab6fca4a705034"
 dependencies = [
- "futures-util",
- "pin-project 0.4.28",
-]
-
-[[package]]
-name = "actix-testing"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47239ca38799ab74ee6a8a94d1ce857014b2ac36f242f70f3f75a66f691e791c"
-dependencies = [
- "actix-macros",
- "actix-rt",
- "actix-server",
- "actix-service",
- "log",
- "socket2 0.3.19",
-]
-
-[[package]]
-name = "actix-threadpool"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d209f04d002854b9afd3743032a27b066158817965bf5d036824d19ac2cc0e30"
-dependencies = [
- "derive_more",
- "futures-channel",
- "lazy_static",
- "log",
- "num_cpus",
- "parking_lot",
- "threadpool",
+ "futures-core",
+ "paste",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "actix-tls"
-version = "2.0.0"
+version = "3.0.0-beta.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24789b7d7361cf5503a504ebe1c10806896f61e96eca9a7350e23001aca715fb"
-dependencies = [
- "actix-codec",
- "actix-service",
- "actix-utils",
- "futures-util",
-]
-
-[[package]]
-name = "actix-utils"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9022dec56632d1d7979e59af14f0597a28a830a9c1c7fec8b2327eb9f16b5a"
+checksum = "65b7bb60840962ef0332f7ea01a57d73a24d2cb663708511ff800250bbfef569"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
- "bitflags",
- "bytes 0.5.6",
- "either",
- "futures-channel",
- "futures-sink",
- "futures-util",
+ "actix-utils",
+ "derive_more",
+ "futures-core",
+ "http",
  "log",
- "pin-project 0.4.28",
- "slab",
+ "tokio-util",
+]
+
+[[package]]
+name = "actix-utils"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e491cbaac2e7fc788dfff99ff48ef317e23b3cf63dbaf7aaab6418f40f92aa94"
+dependencies = [
+ "local-waker",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "actix-web"
-version = "3.3.2"
+version = "4.0.0-beta.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e641d4a172e7faa0862241a20ff4f1f5ab0ab7c279f00c2d4587b77483477b86"
+checksum = "ff12e933051557d700b0fcad20fe25b9ca38395cc87bbc5aeaddaef17b937a2f"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -226,37 +164,37 @@ dependencies = [
  "actix-rt",
  "actix-server",
  "actix-service",
- "actix-testing",
- "actix-threadpool",
- "actix-tls",
  "actix-utils",
  "actix-web-codegen",
- "awc",
- "bytes 0.5.6",
+ "ahash",
+ "bytes",
+ "cookie",
  "derive_more",
+ "either",
  "encoding_rs",
- "futures-channel",
  "futures-core",
  "futures-util",
- "fxhash",
+ "itoa",
+ "language-tags",
  "log",
  "mime",
- "pin-project 1.0.7",
+ "once_cell",
+ "pin-project",
  "regex",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "socket2 0.3.19",
+ "smallvec",
+ "socket2",
  "time 0.2.26",
- "tinyvec",
  "url",
 ]
 
 [[package]]
 name = "actix-web-codegen"
-version = "0.4.0"
+version = "0.5.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad26f77093333e0e7c6ffe54ebe3582d908a104e448723eec6d43d08b07143fb"
+checksum = "7f138ac357a674c3b480ddb7bbd894b13c1b6e8927d728bc9ea5e17eee2f8fc9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -310,7 +248,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -364,30 +302,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "awc"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b381e490e7b0cfc37ebc54079b0413d8093ef43d14a4e4747083f7fa47a9e691"
-dependencies = [
- "actix-codec",
- "actix-http",
- "actix-rt",
- "actix-service",
- "base64",
- "bytes 0.5.6",
- "cfg-if 1.0.0",
- "derive_more",
- "futures-core",
- "log",
- "mime",
- "percent-encoding",
- "rand 0.7.3",
- "serde",
- "serde_json",
- "serde_urlencoded",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,7 +309,7 @@ checksum = "4717cfcbfaa661a0fd48f8453951837ae7e8f81e481fbb136e3202d72805a744"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide 0.4.4",
  "object",
@@ -520,12 +434,6 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
-
-[[package]]
-name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
@@ -536,7 +444,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90706ba19e97b90786e19dc0d5e2abd80008d99d4c0c5d1ad0b5e72cec7c494d"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
 ]
 
 [[package]]
@@ -546,10 +454,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 
 [[package]]
-name = "cfg-if"
-version = "0.1.10"
+name = "cfb"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+checksum = "ca453e8624711b2f0f4eb47076a318feda166252a827ee25d067b43de83dcba0"
+dependencies = [
+ "byteorder",
+ "uuid",
+]
 
 [[package]]
 name = "cfg-if"
@@ -568,7 +480,7 @@ dependencies = [
  "num-traits",
  "serde",
  "time 0.1.43",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -583,11 +495,11 @@ version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc4369b5e4c0cddf64ad8981c0111e7df4f7078f4d6ba98fb31f2e17c4c57b7e"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "futures-util",
  "memchr",
- "pin-project-lite 0.2.6",
- "tokio 1.6.0",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -604,20 +516,14 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cookie"
-version = "0.14.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
+checksum = "ffdf8865bac3d9a3bde5bde9088ca431b11f5d37c7a578b8086af77248b76627"
 dependencies = [
  "percent-encoding",
  "time 0.2.26",
  "version_check",
 ]
-
-[[package]]
-name = "copyless"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2df960f5d869b2dd8532793fde43eb5427cceb126c929747a26823ab0eeb536"
 
 [[package]]
 name = "core-foundation"
@@ -659,7 +565,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -668,7 +574,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -678,7 +584,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -689,7 +595,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52fb27eab85b17fbb9f6fd667089e07d6a2eb8743d02639ee7f6a7a7729c9c94"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
@@ -702,7 +608,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f6cb3c7f5b8e51bc3ebb73a2327ad4abdbd119dc13223f14f961d2f38486756"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -713,7 +619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "lazy_static",
 ]
 
@@ -819,7 +725,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "dirs-sys-next",
 ]
 
@@ -831,7 +737,7 @@ checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
 dependencies = [
  "libc",
  "redox_users",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -842,7 +748,7 @@ checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -894,7 +800,7 @@ dependencies = [
  "serde_json",
  "sha-1 0.9.6",
  "thiserror",
- "tokio 1.6.0",
+ "tokio",
  "url",
 ]
 
@@ -919,19 +825,7 @@ version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "enum-as-inner"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
+ "cfg-if",
 ]
 
 [[package]]
@@ -998,7 +892,7 @@ version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crc32fast",
  "libc",
  "miniz_oxide 0.4.4",
@@ -1098,6 +992,7 @@ dependencies = [
  "hamming",
  "handlebars",
  "hyper",
+ "infer",
  "lazy_static",
  "linkify",
  "opentelemetry",
@@ -1115,7 +1010,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tgbotapi",
- "tokio 1.6.0",
+ "tokio",
  "tokio-stream",
  "tracing",
  "tracing-log",
@@ -1142,15 +1037,19 @@ dependencies = [
  "fuzzysearch",
  "hamming",
  "image",
+ "infer",
  "opentelemetry",
  "opentelemetry-jaeger",
  "redis",
+ "rusoto_core",
+ "rusoto_credential",
+ "rusoto_s3",
  "serde",
  "serde_json",
  "sqlx",
  "tgbotapi",
  "thiserror",
- "tokio 1.6.0",
+ "tokio",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -1191,7 +1090,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "thiserror",
- "tokio 1.6.0",
+ "tokio",
  "tracing",
  "url",
 ]
@@ -1201,7 +1100,7 @@ name = "foxbot-utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bytes 1.0.1",
+ "bytes",
  "fluent",
  "fluent-langneg",
  "foxbot-models",
@@ -1223,29 +1122,13 @@ dependencies = [
  "sha2",
  "sqlx",
  "tgbotapi",
- "tokio 1.6.0",
+ "tokio",
  "tokio-stream",
  "tracing",
  "tracing-futures",
  "tracing-opentelemetry",
  "unic-langid",
 ]
-
-[[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "funty"
@@ -1350,7 +1233,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.6",
+ "pin-project-lite",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1418,7 +1301,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -1429,7 +1312,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
 ]
@@ -1452,31 +1335,11 @@ checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
 
 [[package]]
 name = "h2"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
-dependencies = [
- "bytes 0.5.6",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap",
- "slab",
- "tokio 0.2.25",
- "tokio-util 0.3.1",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "h2"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1484,8 +1347,8 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.6.0",
- "tokio-util 0.6.7",
+ "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -1504,7 +1367,7 @@ dependencies = [
  "log",
  "pest",
  "pest_derive",
- "quick-error 2.0.1",
+ "quick-error",
  "serde",
  "serde_json",
  "walkdir",
@@ -1576,7 +1439,7 @@ checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
 dependencies = [
  "libc",
  "match_cfg",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1599,7 +1462,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "fnv",
  "itoa",
 ]
@@ -1610,9 +1473,9 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "http",
- "pin-project-lite 0.2.6",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1639,19 +1502,19 @@ version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3f71a7eea53a3f8257a7b4795373ff886397178cd634430ea94e12d7fe4fe34"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.3",
+ "h2",
  "http",
  "http-body",
  "httparse",
  "httpdate 1.0.1",
  "itoa",
- "pin-project 1.0.7",
- "socket2 0.4.0",
- "tokio 1.6.0",
+ "pin-project",
+ "socket2",
+ "tokio",
  "tower-service",
  "tracing",
  "want",
@@ -1663,10 +1526,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "hyper",
  "native-tls",
- "tokio 1.6.0",
+ "tokio",
  "tokio-native-tls",
 ]
 
@@ -1724,12 +1587,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "infer"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea70330449622910e0edebab230734569516269fb32342fb0a8956340fa48c6c"
+dependencies = [
+ "cfb",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1756,27 +1628,6 @@ checksum = "b18f988384267d7066cc2be425e6faf352900652c046b6971d2e228d3b1c5ecf"
 dependencies = [
  "tinystr",
  "unic-langid",
-]
-
-[[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "ipconfig"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7"
-dependencies = [
- "socket2 0.3.19",
- "widestring",
- "winapi 0.3.9",
- "winreg 0.6.2",
 ]
 
 [[package]]
@@ -1810,16 +1661,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "language-tags"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1839,7 +1680,7 @@ checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
  "arrayvec",
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "ryu",
  "static_assertions",
 ]
@@ -1851,12 +1692,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
-
-[[package]]
 name = "linkify"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1864,6 +1699,24 @@ checksum = "78d59d732ba6d7eeefc418aab8057dc8e3da4374bd5802ffa95bebc04b4d1dfb"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "local-channel"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6246c68cf195087205a0512559c97e15eaf95198bf0e206d662092cdcb03fe9f"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "local-waker",
+]
+
+[[package]]
+name = "local-waker"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84f9a2d3e27ce99ce2c3aad0b09b1a7b916293ea9b2bf624c13fe646fadd8da4"
 
 [[package]]
 name = "lock_api"
@@ -1880,16 +1733,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "lru-cache"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
+ "cfg-if",
 ]
 
 [[package]]
@@ -2008,57 +1852,15 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
-dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
- "libc",
- "log",
- "miow 0.2.2",
- "net2",
- "slab",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "mio"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
 dependencies = [
  "libc",
  "log",
- "miow 0.3.7",
+ "miow",
  "ntapi",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "mio-uds"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
-dependencies = [
- "iovec",
- "libc",
- "mio 0.6.23",
-]
-
-[[package]]
-name = "miow"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
-dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -2067,7 +1869,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2086,17 +1888,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "net2"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2130,7 +1921,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2225,7 +2016,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
@@ -2262,10 +2053,10 @@ dependencies = [
  "js-sys",
  "lazy_static",
  "percent-encoding",
- "pin-project 1.0.7",
+ "pin-project",
  "rand 0.8.3",
  "thiserror",
- "tokio 1.6.0",
+ "tokio",
  "tokio-stream",
 ]
 
@@ -2292,7 +2083,7 @@ dependencies = [
  "opentelemetry",
  "thiserror",
  "thrift",
- "tokio 1.6.0",
+ "tokio",
 ]
 
 [[package]]
@@ -2321,13 +2112,19 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "instant",
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi 0.3.9",
+ "winapi",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
 
 [[package]]
 name = "percent-encoding"
@@ -2434,31 +2231,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "918192b5c59119d51e0cd221f4d49dde9112824ba717369e903c97d076083d0f"
-dependencies = [
- "pin-project-internal 0.4.28",
-]
-
-[[package]]
-name = "pin-project"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
 dependencies = [
- "pin-project-internal 1.0.7",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "0.4.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be26700300be6d9d23264c73211d8190e755b6b5ca7a1b28230025511b52a5e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "pin-project-internal",
 ]
 
 [[package]]
@@ -2471,12 +2248,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
@@ -2561,7 +2332,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5986aa8d62380092d2f50f8b1cdba9cb9b6731ffd4b25b51fd126b6c3e05b99c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fnv",
  "lazy_static",
  "libc",
@@ -2577,12 +2348,6 @@ name = "protobuf"
 version = "2.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45604fc7a88158e7d514d8e22e14ac746081e7a70d7690074dd0029ee37458d6"
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-error"
@@ -2729,17 +2494,17 @@ checksum = "0a32cb439c4e89c1e6415e5b3b23d9d8cc6dc1bf5a8cade19adbd5418de803be"
 dependencies = [
  "arc-swap",
  "async-trait",
- "bytes 1.0.1",
+ "bytes",
  "combine",
  "dtoa",
  "futures",
  "futures-util",
  "itoa",
  "percent-encoding",
- "pin-project-lite 0.2.6",
+ "pin-project-lite",
  "sha1",
- "tokio 1.6.0",
- "tokio-util 0.6.7",
+ "tokio",
+ "tokio-util",
  "url",
 ]
 
@@ -2795,7 +2560,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2826,7 +2591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2296f2fac53979e8ccbc4a1136b25dcefd37be9ed7e4a1f6b05a6029c84ff124"
 dependencies = [
  "base64",
- "bytes 1.0.1",
+ "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -2842,27 +2607,17 @@ dependencies = [
  "mime_guess",
  "native-tls",
  "percent-encoding",
- "pin-project-lite 0.2.6",
+ "pin-project-lite",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.6.0",
+ "tokio",
  "tokio-native-tls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg 0.7.0",
-]
-
-[[package]]
-name = "resolv-conf"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
-dependencies = [
- "hostname",
- "quick-error 1.2.3",
+ "winreg",
 ]
 
 [[package]]
@@ -2877,7 +2632,7 @@ dependencies = [
  "spin",
  "untrusted",
  "web-sys",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2888,7 +2643,7 @@ checksum = "02aff20978970d47630f08de5f0d04799497818d16cafee5aec90c4b4d0806cf"
 dependencies = [
  "async-trait",
  "base64",
- "bytes 1.0.1",
+ "bytes",
  "crc32fast",
  "futures",
  "http",
@@ -2901,7 +2656,7 @@ dependencies = [
  "rustc_version 0.2.3",
  "serde",
  "serde_json",
- "tokio 1.6.0",
+ "tokio",
  "xml-rs",
 ]
 
@@ -2919,7 +2674,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shlex",
- "tokio 1.6.0",
+ "tokio",
  "zeroize",
 ]
 
@@ -2930,7 +2685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abc3f56f14ccf91f880b9a9c2d0556d8523e8c155041c54db155b384a1dd1119"
 dependencies = [
  "async-trait",
- "bytes 1.0.1",
+ "bytes",
  "futures",
  "rusoto_core",
  "xml-rs",
@@ -2943,7 +2698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5486e6b1673ab3e0ba1ded284fb444845fe1b7f41d13989a54dd60f62a7b2baa"
 dependencies = [
  "base64",
- "bytes 1.0.1",
+ "bytes",
  "futures",
  "hex",
  "hmac",
@@ -2952,13 +2707,13 @@ dependencies = [
  "log",
  "md5",
  "percent-encoding",
- "pin-project-lite 0.2.6",
+ "pin-project-lite",
  "rusoto_credential",
  "rustc_version 0.2.3",
  "serde",
  "sha2",
  "time 0.2.26",
- "tokio 1.6.0",
+ "tokio",
 ]
 
 [[package]]
@@ -3048,7 +2803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3330,7 +3085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c4cfa741c5832d0ef7fab46cabed29c2aae926db0b11bb2069edd8db5e64e16"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -3349,7 +3104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -3399,23 +3154,12 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "socket2"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3458,7 +3202,7 @@ dependencies = [
  "base64",
  "bitflags",
  "byteorder",
- "bytes 1.0.1",
+ "bytes",
  "chrono",
  "crc",
  "crossbeam-channel",
@@ -3529,7 +3273,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8199b421ecf3493ee9ef3e7bc90c904844cfb2ea7ea2f57347a93f52bfd3e057"
 dependencies = [
  "once_cell",
- "tokio 1.6.0",
+ "tokio",
  "tokio-rustls",
 ]
 
@@ -3685,12 +3429,12 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "rand 0.8.3",
  "redox_syscall",
  "remove_dir_all",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3792,7 +3536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3807,7 +3551,7 @@ dependencies = [
  "stdweb",
  "time-macros",
  "version_check",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3856,42 +3600,22 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
-dependencies = [
- "bytes 0.5.6",
- "futures-core",
- "iovec",
- "lazy_static",
- "libc",
- "memchr",
- "mio 0.6.23",
- "mio-uds",
- "pin-project-lite 0.1.12",
- "signal-hook-registry",
- "slab",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "tokio"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd3076b5c8cc18138b8f8814895c11eb4de37114a5d127bafdc5e55798ceef37"
 dependencies = [
  "autocfg",
- "bytes 1.0.1",
+ "bytes",
  "libc",
  "memchr",
- "mio 0.7.11",
+ "mio",
  "num_cpus",
  "once_cell",
  "parking_lot",
- "pin-project-lite 0.2.6",
+ "pin-project-lite",
  "signal-hook-registry",
  "tokio-macros",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3912,7 +3636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.6.0",
+ "tokio",
 ]
 
 [[package]]
@@ -3922,7 +3646,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
  "rustls",
- "tokio 1.6.0",
+ "tokio",
  "webpki",
 ]
 
@@ -3933,22 +3657,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8864d706fdb3cc0843a49647ac892720dac98a6eeb818b77190592cf4994066"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.6",
- "tokio 1.6.0",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
-dependencies = [
- "bytes 0.5.6",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite 0.1.12",
- "tokio 0.2.25",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -3957,12 +3667,12 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.2.6",
- "tokio 1.6.0",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -3977,9 +3687,8 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
- "cfg-if 1.0.0",
- "log",
- "pin-project-lite 0.2.6",
+ "cfg-if",
+ "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -4010,7 +3719,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project 1.0.7",
+ "pin-project",
  "tracing",
 ]
 
@@ -4084,45 +3793,6 @@ checksum = "95f9c900aa98b6ea43aee227fd680550cdec726526aab8ac801549eadb25e39f"
 dependencies = [
  "num-integer",
  "strength_reduce",
-]
-
-[[package]]
-name = "trust-dns-proto"
-version = "0.19.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cad71a0c0d68ab9941d2fb6e82f8fb2e86d9945b94e1661dd0aaea2b88215a9"
-dependencies = [
- "async-trait",
- "cfg-if 1.0.0",
- "enum-as-inner",
- "futures",
- "idna",
- "lazy_static",
- "log",
- "rand 0.7.3",
- "smallvec",
- "thiserror",
- "tokio 0.2.25",
- "url",
-]
-
-[[package]]
-name = "trust-dns-resolver"
-version = "0.19.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710f593b371175db53a26d0b38ed2978fafb9e9e8d3868b1acd753ea18df0ceb"
-dependencies = [
- "cfg-if 0.1.10",
- "futures",
- "ipconfig",
- "lazy_static",
- "log",
- "lru-cache",
- "resolv-conf",
- "smallvec",
- "thiserror",
- "tokio 0.2.25",
- "trust-dns-proto",
 ]
 
 [[package]]
@@ -4284,7 +3954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
- "winapi 0.3.9",
+ "winapi",
  "winapi-util",
 ]
 
@@ -4316,7 +3986,7 @@ version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -4343,7 +4013,7 @@ version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -4424,18 +4094,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "widestring"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
-
-[[package]]
-name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4444,12 +4102,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -4463,7 +4115,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -4474,30 +4126,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winreg"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "winreg"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,7 +991,6 @@ dependencies = [
  "hamming",
  "handlebars",
  "hyper",
- "infer",
  "lazy_static",
  "linkify",
  "opentelemetry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,6 +805,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "fuzzysearch",
  "lazy_static",
  "prometheus",
  "redis",
@@ -2906,6 +2907,7 @@ dependencies = [
  "bitflags",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "crossbeam-channel",
  "crossbeam-queue",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,9 +20,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.0.0-beta.6"
+version = "3.0.0-beta.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59d51c2ba06062e698a5d212d860e9fb2afc931c285ede687aaae896c8150347"
+checksum = "fb9c5d7ceb490d6565156ae1d4d467db17da1759425c65a2e36ac5e182e014e2"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -35,6 +35,7 @@ dependencies = [
  "brotli2",
  "bytes",
  "bytestring",
+ "cookie",
  "derive_more",
  "encoding_rs",
  "flate2",
@@ -49,13 +50,14 @@ dependencies = [
  "log",
  "mime",
  "once_cell",
- "paste",
  "percent-encoding",
  "pin-project",
  "pin-project-lite",
  "rand 0.8.3",
  "regex",
  "serde",
+ "serde_json",
+ "serde_urlencoded",
  "sha-1 0.9.6",
  "smallvec",
  "time 0.2.26",
@@ -98,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "2.0.0-beta.5"
+version = "2.0.0-beta.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26369215fcc3b0176018b3b68756a8bcc275bb000e6212e454944913a1f9bf87"
+checksum = "0872f02a1871257ef09c5a269dce5dc5fea5ccf502adbf5d39f118913b61411c"
 dependencies = [
  "actix-rt",
  "actix-service",
@@ -115,12 +117,11 @@ dependencies = [
 
 [[package]]
 name = "actix-service"
-version = "2.0.0"
+version = "2.0.0-beta.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f5f9d66a8730d0fae62c26f3424f5751e5518086628a40b7ab6fca4a705034"
+checksum = "cf82340ad9f4e4caf43737fd3bbc999778a268015cdc54675f60af6240bd2b05"
 dependencies = [
  "futures-core",
- "paste",
  "pin-project-lite",
 ]
 
@@ -153,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.0.0-beta.6"
+version = "4.0.0-beta.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff12e933051557d700b0fcad20fe25b9ca38395cc87bbc5aeaddaef17b937a2f"
+checksum = "6de19cc341c2e68b1ee126de171e86b610b5bbcecc660d1250ebed73e0257bd6"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -168,13 +169,11 @@ dependencies = [
  "actix-web-codegen",
  "ahash",
  "bytes",
- "cookie",
  "derive_more",
  "either",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "itoa",
  "language-tags",
  "log",
  "mime",
@@ -410,9 +409,9 @@ checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
 
 [[package]]
 name = "bumpalo"
-version = "3.6.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
 name = "byte-tools"
@@ -516,9 +515,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cookie"
-version = "0.15.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf8865bac3d9a3bde5bde9088ca431b11f5d37c7a578b8086af77248b76627"
+checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
 dependencies = [
  "percent-encoding",
  "time 0.2.26",
@@ -1013,6 +1012,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "tracing-actix-web",
  "tracing-log",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -2119,12 +2119,6 @@ dependencies = [
  "smallvec",
  "winapi",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
 
 [[package]]
 name = "percent-encoding"
@@ -3600,9 +3594,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd3076b5c8cc18138b8f8814895c11eb4de37114a5d127bafdc5e55798ceef37"
+checksum = "0a38d31d7831c6ed7aad00aa4c12d9375fd225a6dd77da1d25b707346319a975"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3691,6 +3685,23 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-actix-web"
+version = "0.4.0-beta.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d232c700ac99b41f56aac3832f138009b2dc7538cbdc76fdc6b8304a1ee2d2e0"
+dependencies = [
+ "actix-http",
+ "actix-service",
+ "actix-web",
+ "futures",
+ "opentelemetry",
+ "tracing",
+ "tracing-futures",
+ "tracing-opentelemetry",
+ "uuid",
 ]
 
 [[package]]
@@ -3869,9 +3880,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
+checksum = "33717dca7ac877f497014e10d73f3acf948c342bee31b5ca7892faf94ccc6b49"
 dependencies = [
  "tinyvec",
 ]

--- a/README.md
+++ b/README.md
@@ -4,50 +4,56 @@ Telegram bot for easily collecting furry images from multiple sites.
 
 It also supports ways of sourcing images including through sending images directly to the bot, using commands in groups, automatically adding sources to images posted in groups, or editing messages in channels to include the source.
 
-Written as the successor of [furryimgbot](https://git.huefox.com/syfaro/telegram-furryimgbot).
-
 It currently supports a number of sites:
 
-* FurAffinity (including source finding via [fuzzysearch.net](https://fuzzysearch.net))
-* Mastodon
-* Weasyl
-* Twitter
-* e621 (finds original link from direct image links)
-* direct links
+- FurAffinity (including source finding via [fuzzysearch.net](https://fuzzysearch.net))
+- Mastodon
+- Weasyl
+- Twitter
+- e621 (finds original link from direct image links)
+- direct links
 
 It also supports trying to reverse image search images sent directly using [fuzzysearch.net](https://fuzzysearch.net).
 
+For more details, see the [blog post](https://syfaro.net/blog/foxbot/) explaining all the features.
+
 ## Configuration
 
-Env Name                   | Description
----------------------------|------------
-`FA_A`                     | FurAffinity cookie 'a' from authenticated user
-`FA_B`                     | FurAffinity cookie 'b' from authenticated user
-`WEASYL_APITOKEN`          | API Token for [weasyl.com](https://www.weasyl.com)
-`INKBUNNY_USERNAME`        | Username for [Inkbunny](https://inkbunny.net)
-`INKBUNNY_PASSWORD`        | Password for [Inkbunny](https://inkbunny.net)
-`TWITTER_CONSUMER_KEY`     | Twitter app consumer key
-`TWITTER_CONSUMER_KEY`     | Twitter app consumer secret
-`TWITTER_CALLBACK`         | Twitter callback URL for authentication
-`JAEGER_COLLECTOR`         | Jaeger collector endpoint
-`SENTRY_DSN`               | Optional, Sentry DSN to report errors
-`SENTRY_ORGANIZATION_SLUG` | Optional, Sentry organization slug for user error messages
-`SENTRY_PROJECT_SLUG`      | Optional, Sentry project slug for user error messages
-`TELEGRAM_APITOKEN`        | API Token for Telegram, from Botfather
-`USE_WEBHOOKS`             | Optional, if should configure and use webhooks instead of polling
-`WEBHOOK_ENDPOINT`         | Optional, if using webhooks, endpoint to set with Telegram
-`HTTP_HOST`                | Optional, host to listen for webhooks
-`HTTP_SECRET`              | Optional, if using webhooks, secret endpoint to use for Telegram updates
-`S3_ENDPOINT`              | Endpoint for S3 for cached images and video storage
-`S3_REGION`                | Region for S3
-`S3_TOKEN`                 | S3 access token
-`S3_SECRET`                | S3 secret token
-`S3_BUCKET`                | S3 bucket
-`S3_URL`                   | URL to use for generating path to file in S3 bucket
-`FAUTIL_APITOKEN`          | API Token for [fuzzysearch.net](https://fuzzysearch.net)
-`CACHE_ALL_IMAGES`         | Optional, download and cache all inline images
-`METRICS_HOST`             | Host to expose Prometheus metrics, health check
-`DB_HOST`                  | Host for PostgreSQL database
-`DB_USER`                  | User for PostgreSQL database
-`DB_PASS`                  | Password for PostgreSQL database
-`DB_NAME`                  | Name of PostgreSQL database
+All fields are required, unless otherwise specified.
+
+| Env Name                   | Description                                                 |
+| -------------------------- | ----------------------------------------------------------- |
+| `FA_A`                     | FurAffinity cookie 'a' from authenticated user              |
+| `FA_B`                     | FurAffinity cookie 'b' from authenticated user              |
+| `WEASYL_APITOKEN`          | API Token for [weasyl.com](https://www.weasyl.com)          |
+| `INKBUNNY_USERNAME`        | Username for [Inkbunny](https://inkbunny.net)               |
+| `INKBUNNY_PASSWORD`        | Password for [Inkbunny](https://inkbunny.net)               |
+| `E621_LOGIN`               | Username for [e621](https://e621.net)                       |
+| `E621_API_KEY`             | API key for [e621](https://e621.net)                        |
+| `FAUTIL_APITOKEN`          | API Token for [fuzzysearch.net](https://fuzzysearch.net)    |
+| `TWITTER_CONSUMER_KEY`     | Twitter app consumer key                                    |
+| `TWITTER_CONSUMER_KEY`     | Twitter app consumer secret                                 |
+| `TWITTER_CALLBACK`         | Twitter callback URL for authentication                     |
+| `JAEGER_COLLECTOR`         | Jaeger collector endpoint                                   |
+| `SENTRY_DSN`               | Optional, Sentry DSN to report errors                       |
+| `SENTRY_ORGANIZATION_SLUG` | Optional, Sentry organization slug for user error messages  |
+| `SENTRY_PROJECT_SLUG`      | Optional, Sentry project slug for user error messages       |
+| `TELEGRAM_APITOKEN`        | API Token for Telegram, from Botfather                      |
+| `S3_ENDPOINT`              | Endpoint for S3 for cached images and video storage         |
+| `S3_REGION`                | Region for S3                                               |
+| `S3_TOKEN`                 | S3 access token                                             |
+| `S3_SECRET`                | S3 secret token                                             |
+| `S3_BUCKET`                | S3 bucket                                                   |
+| `S3_URL`                   | URL to use for generating path to file in S3 bucket         |
+| `B2_ACCOUNT_ID`            | Backblaze B2 account ID for encoded videos                  |
+| `B2_APP_KEY`               | Backblaze B2 app key for encoded videos                     |
+| `B2_BUCKET_ID`             | Backblaze B2 bucket ID for encoded videos                   |
+| `COCONUT_APITOKEN`         | API token for [Coconut](https://coconut.co)                 |
+| `COCONUT_SECRET`           | Secret for [Coconut](https://coconut.co) webhooks           |
+| `CACHE_ALL_IMAGES`         | Optional, download and cache all inline images              |
+| `REDIS_DSN`                | Redis connection URL                                        |
+| `FAKTORY_URL`              | Faktory connection URL                                      |
+| `DATABASE_URL`             | PostgreSQL connection URL                                   |
+| `INTERNET_URL`             | URL base for all webhooks and served data                   |
+| `INTERNAL_SECRET`          | Secret key to access health and metrics                     |
+| `BACKGROUND_WORKERS`       | Optional, number of concurrent workers for background tasks |

--- a/foxbot-background-worker/Cargo.toml
+++ b/foxbot-background-worker/Cargo.toml
@@ -23,6 +23,10 @@ dotenv = { version = "0.15", optional = true }
 
 sqlx = { version = "0.5", default-features = false, features = ["runtime-tokio-rustls", "macros", "postgres", "offline", "json"] }
 
+rusoto_core = "0.46"
+rusoto_credential = "0.46"
+rusoto_s3 = "0.46"
+
 faktory = "0.11"
 chrono = "0.4"
 tokio = "1"
@@ -30,6 +34,7 @@ redis = { version = "0.20", features = ["connection-manager", "tokio-comp"] }
 
 image = "0.23"
 hamming = "0.1"
+infer = "0.5"
 
 tgbotapi = { git = "https://github.com/Syfaro/tgbotapi-rs" }
 fuzzysearch = { git = "https://github.com/Syfaro/fuzzysearch-rs", features = ["trace", "local_hash"] }

--- a/foxbot-background-worker/src/group.rs
+++ b/foxbot-background-worker/src/group.rs
@@ -36,6 +36,19 @@ pub async fn process_group_photo(handler: Arc<Handler>, job: faktory::Job) -> Re
         }
     }
 
+    if message.media_group_id.is_some()
+        && GroupConfig::get(
+            &handler.conn,
+            message.chat.id,
+            GroupConfigKey::GroupNoAlbums,
+        )
+        .await?
+        .unwrap_or(false)
+    {
+        tracing::trace!("group is ignoring media groups");
+        return Ok(());
+    }
+
     match is_controlled_channel(&handler, &message).await {
         Ok(true) => {
             tracing::debug!("message was forwarded from controlled channel");

--- a/foxbot-background-worker/src/main.rs
+++ b/foxbot-background-worker/src/main.rs
@@ -83,11 +83,7 @@ fn main() {
 
     tracing::info!("starting channel worker");
 
-    let workers: usize = std::env::var("CHANNEL_WORKERS")
-        .as_deref()
-        .unwrap_or("2")
-        .parse()
-        .unwrap_or(4);
+    let workers: usize = config.background_workers.unwrap_or(4);
 
     tracing::debug!(workers, "got worker count configuration");
 
@@ -280,7 +276,7 @@ struct Config {
     s3_secret: String,
 
     // Worker configuration
-    channel_workers: Option<usize>,
+    background_workers: Option<usize>,
     database_url: String,
     redis_dsn: String,
     internet_url: String,

--- a/foxbot-background-worker/src/main.rs
+++ b/foxbot-background-worker/src/main.rs
@@ -283,7 +283,7 @@ struct Config {
     channel_workers: Option<usize>,
     database_url: String,
     redis_dsn: String,
-    media_group_sources: String,
+    internet_url: String,
 }
 
 #[derive(serde::Deserialize, serde::Serialize)]

--- a/foxbot-background-worker/src/main.rs
+++ b/foxbot-background-worker/src/main.rs
@@ -22,6 +22,13 @@ fn main() {
     use opentelemetry::KeyValue;
     use tracing_subscriber::layer::SubscriberExt;
 
+    load_env();
+    let config = match envy::from_env::<Config>() {
+        Ok(config) => config,
+        Err(err) => panic!("{:#?}", err),
+    };
+    let config_clone = config.clone();
+
     let runtime = Arc::new(
         tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -75,14 +82,6 @@ fn main() {
     }
 
     tracing::info!("starting channel worker");
-
-    load_env();
-    let config = match envy::from_env::<Config>() {
-        Ok(config) => config,
-        Err(err) => panic!("{:#?}", err),
-    };
-
-    let config_clone = config.clone();
 
     let workers: usize = std::env::var("CHANNEL_WORKERS")
         .as_deref()

--- a/foxbot-background-worker/src/main.rs
+++ b/foxbot-background-worker/src/main.rs
@@ -146,6 +146,18 @@ fn main() {
     worker_environment.register("channel_edit", channel::process_channel_edit);
     worker_environment.register("group_photo", group::process_group_photo);
     worker_environment.register("group_source", group::process_group_source);
+    worker_environment.register(
+        "group_mediagroup_message",
+        group::process_group_mediagroup_message,
+    );
+    worker_environment.register(
+        "group_mediagroup_check",
+        group::process_group_mediagroup_check,
+    );
+    worker_environment.register(
+        "group_mediagroup_hash",
+        group::process_group_mediagroup_hash,
+    );
     worker_environment.register("hash_new", subscribe::process_hash_new);
     worker_environment.register("hash_notify", subscribe::process_hash_notify);
 

--- a/foxbot-models/Cargo.toml
+++ b/foxbot-models/Cargo.toml
@@ -16,7 +16,8 @@ lazy_static = "1"
 serde = "1"
 serde_json = "1"
 
-sqlx = { version = "0.5", default-features = false, features = ["runtime-tokio-rustls", "macros", "postgres", "offline", "json", "migrate", "time"] }
+sqlx = { version = "0.5", default-features = false, features = ["runtime-tokio-rustls", "macros", "postgres", "offline", "json", "migrate", "time", "chrono"] }
 redis = { version = "0.20", features = ["connection-manager", "tokio-comp"] }
 
 tgbotapi = { git = "https://github.com/Syfaro/tgbotapi-rs" }
+fuzzysearch = { git = "https://github.com/Syfaro/fuzzysearch-rs", features = ["trace", "local_hash"] }

--- a/foxbot-models/src/lib.rs
+++ b/foxbot-models/src/lib.rs
@@ -169,6 +169,7 @@ pub struct GroupConfig;
 pub enum GroupConfigKey {
     GroupAdd,
     GroupNoPreviews,
+    GroupNoAlbums,
     HasDeletePermission,
     CanEditChannel,
     HasLinkedChat,
@@ -179,6 +180,7 @@ impl GroupConfigKey {
         match self {
             GroupConfigKey::GroupAdd => "group_add",
             GroupConfigKey::GroupNoPreviews => "group_no_previews",
+            &GroupConfigKey::GroupNoAlbums => "group_no_albums",
             GroupConfigKey::HasDeletePermission => "has_delete_permission",
             GroupConfigKey::CanEditChannel => "can_edit_channel",
             GroupConfigKey::HasLinkedChat => "has_linked_chat",

--- a/foxbot-models/src/lib.rs
+++ b/foxbot-models/src/lib.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use tgbotapi::Message;
 
 lazy_static::lazy_static! {
     static ref CACHE_REQUESTS: prometheus::CounterVec = prometheus::register_counter_vec!("foxbot_cache_requests_total", "Number of file cache hits and misses", &["result"]).unwrap();
@@ -816,5 +817,103 @@ impl Subscriptions {
         .await?;
 
         Ok(subscriptions)
+    }
+}
+
+pub struct MediaGroup {
+    pub id: i32,
+    pub inserted_at: chrono::DateTime<chrono::Utc>,
+    pub message: Message,
+    pub sources: Option<Vec<fuzzysearch::File>>,
+}
+
+impl MediaGroup {
+    /// Store a message as part of a media group, keeping track of when the
+    /// value was inserted.
+    pub async fn add_message(
+        conn: &sqlx::Pool<sqlx::Postgres>,
+        message: &Message,
+    ) -> anyhow::Result<i32> {
+        let id = sqlx::query_scalar!(
+            "INSERT INTO media_group (media_group_id, inserted_at, message) VALUES ($1, $2, $3) RETURNING id",
+            message.media_group_id.as_ref().unwrap(),
+            chrono::Utc::now(),
+            serde_json::to_value(message)?,
+        )
+        .fetch_one(conn)
+        .await?;
+        Ok(id)
+    }
+
+    /// Get the time that the last message was inserted to the media group.
+    pub async fn last_message(
+        conn: &sqlx::Pool<sqlx::Postgres>,
+        media_group_id: &str,
+    ) -> anyhow::Result<Option<chrono::DateTime<chrono::Utc>>> {
+        let last_inserted_at = sqlx::query_scalar!(
+            r#"SELECT max(inserted_at) FROM media_group WHERE media_group_id = $1"#,
+            media_group_id
+        )
+        .fetch_optional(conn)
+        .await?;
+        Ok(last_inserted_at.flatten())
+    }
+
+    /// Get a specific stored message, if it exists.
+    pub async fn get_message(
+        conn: &sqlx::Pool<sqlx::Postgres>,
+        id: i32,
+    ) -> anyhow::Result<Option<MediaGroup>> {
+        let message = sqlx::query!(
+            "SELECT id, inserted_at, message, sources FROM media_group WHERE id = $1",
+            id
+        )
+        .map(|row| MediaGroup {
+            id: row.id,
+            inserted_at: row.inserted_at,
+            message: serde_json::from_value(row.message).unwrap(),
+            sources: row
+                .sources
+                .map(|sources| serde_json::from_value(sources).unwrap()),
+        })
+        .fetch_optional(conn)
+        .await?;
+
+        Ok(message)
+    }
+
+    /// Update the sources of a stored message, discarding any errors.
+    pub async fn set_message_sources(
+        conn: &sqlx::Pool<sqlx::Postgres>,
+        id: i32,
+        sources: Vec<fuzzysearch::File>,
+    ) {
+        let _ = sqlx::query!(
+            "UPDATE media_group SET sources = $1 WHERE id = $2",
+            serde_json::to_value(sources).unwrap(),
+            id
+        )
+        .execute(conn)
+        .await;
+    }
+
+    /// Consume (delete and return) all messages stored in the media group.
+    pub async fn consume_messages(
+        conn: &sqlx::Pool<sqlx::Postgres>,
+        media_group_id: &str,
+    ) -> anyhow::Result<Vec<MediaGroup>> {
+        let messages = sqlx::query!(
+            "DELETE FROM media_group WHERE media_group_id = $1 RETURNING id, inserted_at, message, sources",
+            media_group_id
+        )
+        .map(|row| MediaGroup {
+            id: row.id,
+            inserted_at: row.inserted_at,
+            message: serde_json::from_value(row.message).unwrap(),
+            sources: row.sources.map(|sources| serde_json::from_value(sources).unwrap()),
+        })
+        .fetch_all(conn)
+        .await?;
+        Ok(messages)
     }
 }

--- a/foxbot/Cargo.toml
+++ b/foxbot/Cargo.toml
@@ -21,7 +21,6 @@ hamming = "0.1"
 handlebars = { version = "3", features = ["dir_source"] }
 dotenv = { version = "0.15", optional = true }
 base64 = "0.13"
-infer = "0.5"
 
 sentry = { version = "0.22", default-features = false, features = ["backtrace", "contexts", "panic", "anyhow", "reqwest", "debug-logs"] }
 uuid = "0.8"

--- a/foxbot/Cargo.toml
+++ b/foxbot/Cargo.toml
@@ -21,6 +21,7 @@ hamming = "0.1"
 handlebars = { version = "3", features = ["dir_source"] }
 dotenv = { version = "0.15", optional = true }
 base64 = "0.13"
+infer = "0.5"
 
 sentry = { version = "0.22", default-features = false, features = ["backtrace", "contexts", "panic", "anyhow", "reqwest", "debug-logs"] }
 uuid = "0.8"
@@ -56,8 +57,8 @@ rusoto_core = "0.46"
 rusoto_credential = "0.46"
 rusoto_s3 = "0.46"
 
-actix-web = "3"
-actix-http = "2"
+actix-web = "4.0.0-beta.6"
+actix-http = "3.0.0-beta.6"
 
 foxbot-sites = { path = "../foxbot-sites" }
 foxbot-models = { path = "../foxbot-models" }

--- a/foxbot/Cargo.toml
+++ b/foxbot/Cargo.toml
@@ -57,8 +57,9 @@ rusoto_core = "0.46"
 rusoto_credential = "0.46"
 rusoto_s3 = "0.46"
 
-actix-web = "4.0.0-beta.6"
-actix-http = "3.0.0-beta.6"
+actix-web = "4.0.0-beta.5"
+actix-http = "3.0.0-beta.5"
+tracing-actix-web = "0.4.0-beta.4"
 
 foxbot-sites = { path = "../foxbot-sites" }
 foxbot-models = { path = "../foxbot-models" }

--- a/foxbot/src/handlers/commands.rs
+++ b/foxbot/src/handlers/commands.rs
@@ -61,6 +61,7 @@ impl Handler for CommandHandler {
             "/error" => Err(anyhow::anyhow!("a test error message")),
             "/groupsource" => self.enable_group_source(handler, message).await,
             "/grouppreviews" => self.group_nopreviews(handler, message).await,
+            "/groupalbums" => self.group_noalbums(handler, message).await,
             _ => {
                 tracing::info!(command = ?command.name, "unknown command");
                 return Ok(Ignored);
@@ -702,6 +703,42 @@ impl CommandHandler {
             "automatic-preview-enable"
         } else {
             "automatic-preview-disable"
+        };
+
+        handler.send_generic_reply(message, name).await?;
+
+        Ok(())
+    }
+
+    async fn group_noalbums(
+        &self,
+        handler: &MessageHandler,
+        message: &Message,
+    ) -> anyhow::Result<()> {
+        if !self.is_valid_admin_group(handler, message, false).await? {
+            return Ok(());
+        }
+
+        let result = GroupConfig::get(
+            &handler.conn,
+            message.chat.id,
+            GroupConfigKey::GroupNoAlbums,
+        )
+        .await?
+        .unwrap_or(false);
+
+        GroupConfig::set(
+            &handler.conn,
+            GroupConfigKey::GroupNoAlbums,
+            message.chat.id,
+            !result,
+        )
+        .await?;
+
+        let name = if result {
+            "automatic-album-enable"
+        } else {
+            "automatic-album-disable"
         };
 
         handler.send_generic_reply(message, name).await?;

--- a/foxbot/src/main.rs
+++ b/foxbot/src/main.rs
@@ -310,7 +310,7 @@ async fn main() {
 
     let coconut = coconut::Coconut::new(
         config.coconut_apitoken.clone(),
-        config.coconut_webhook.clone(),
+        format!("{}/coconut/{}", config.internet_url, config.coconut_secret),
         config.b2_account_id.clone(),
         config.b2_app_key.clone(),
         config.b2_bucket_id.clone(),

--- a/foxbot/src/main.rs
+++ b/foxbot/src/main.rs
@@ -339,7 +339,7 @@ async fn main() {
         faktory: Arc::new(std::sync::Mutex::new(faktory)),
 
         sites: Mutex::new(sites),
-        conn: pool,
+        conn: pool.clone(),
         redis,
     });
 
@@ -387,8 +387,8 @@ async fn main() {
     }
 
     std::thread::spawn(|| {
-        actix_web::rt::System::new("foxbot-web").block_on(async move {
-            web::serve(config, inline_tx, update_tx).await;
+        actix_web::rt::System::new().block_on(async move {
+            web::serve(config, inline_tx, update_tx, pool, bot).await;
         });
     });
 

--- a/foxbot/src/main.rs
+++ b/foxbot/src/main.rs
@@ -82,12 +82,9 @@ pub struct Config {
 
     // Video encoding
     coconut_apitoken: String,
-    coconut_webhook: String,
     coconut_secret: String,
 
     // Inline image processing options
-    pub size_images: Option<bool>,
-    pub cache_images: Option<bool>,
     pub cache_all_images: Option<bool>,
 
     // Connections

--- a/foxbot/src/web.rs
+++ b/foxbot/src/web.rs
@@ -303,13 +303,6 @@ pub async fn serve(
             .service(health)
             .service(metrics);
 
-        let external_resources = web::scope("/")
-            .service(telegram_webhook)
-            .service(index)
-            .service(health)
-            .service(twitter_callback)
-            .service(mediagroup);
-
         App::new()
             .wrap(actix_web::middleware::Logger::default())
             .app_data(hbs.clone())
@@ -317,8 +310,12 @@ pub async fn serve(
             .data(bot.clone())
             .data(sender.clone())
             .data(config.clone())
+            .service(telegram_webhook)
+            .service(index)
+            .service(health)
+            .service(twitter_callback)
+            .service(mediagroup)
             .service(internal_resources)
-            .service(external_resources)
     })
     .workers(4)
     .bind("0.0.0.0:8080")

--- a/foxbot/src/web.rs
+++ b/foxbot/src/web.rs
@@ -172,11 +172,13 @@ async fn coconut_webhook(
             .send((service_update, tracing::Span::current()))
             .await
             .unwrap();
+
+        return HttpResponse::Ok().body("Updated progress");
     }
 
     let output_urls = match &data.output_urls {
         Some(output_urls) => output_urls,
-        None => return HttpResponse::BadRequest().finish(),
+        None => return HttpResponse::BadRequest().body("No progress and no output URLs"),
     };
 
     let thumb_url = output_urls.thumbnail.as_ref().unwrap();
@@ -188,7 +190,7 @@ async fn coconut_webhook(
     } else if let Some(url) = &output_urls.video_360p {
         url
     } else {
-        return HttpResponse::BadRequest().body("Unknown video format");
+        return HttpResponse::BadRequest().body("All expected video formats empty");
     };
 
     let service_update = HandlerUpdate::Service(ServiceData::VideoComplete {
@@ -304,7 +306,7 @@ pub async fn serve(
             .service(metrics);
 
         App::new()
-            .wrap(actix_web::middleware::Logger::default())
+            .wrap(tracing_actix_web::TracingLogger::default())
             .app_data(hbs.clone())
             .app_data(conn.clone())
             .data(bot.clone())

--- a/foxbot/src/web.rs
+++ b/foxbot/src/web.rs
@@ -26,7 +26,7 @@ struct CoconutWebHookRequestQuery {
 #[derive(Deserialize)]
 struct CoconutWebHookRequestBodyOutputUrls {
     #[serde(rename = "jpg:250x0")]
-    thumbnail: Option<String>,
+    thumbnail: Option<Vec<String>>,
     #[serde(rename = "mp4:720p")]
     video_720p: Option<String>,
     #[serde(rename = "mp4:480p")]
@@ -194,7 +194,7 @@ async fn coconut_webhook(
     let service_update = HandlerUpdate::Service(ServiceData::VideoComplete {
         display_name,
         video_url: video_url.to_owned(),
-        thumb_url: thumb_url.to_owned(),
+        thumb_url: thumb_url.first().unwrap().to_owned(),
     });
 
     sender
@@ -311,6 +311,8 @@ pub async fn serve(
             .data(sender.clone())
             .data(config.clone())
             .service(telegram_webhook)
+            .service(coconut_webhook)
+            .service(fuzzysearch_webhook)
             .service(index)
             .service(health)
             .service(twitter_callback)

--- a/langs/en-US/foxbot.ftl
+++ b/langs/en-US/foxbot.ftl
@@ -106,6 +106,8 @@ automatic-disable = This feature is now turned off.
 automatic-enable-not-group = This feature is only supported in groups.
 automatic-preview-disable = Sourced image previews disabled.
 automatic-preview-enable = Sourced image previews enabled.
+automatic-album-enable = Album sourcing enabled.
+automatic-album-disable = Album sourcing disabled.
 
 # Error Messages
 error-generic = Oh no, something went wrong! Please send a message to my creator, { -creatorName }, saying what happened.

--- a/langs/en-US/foxbot.ftl
+++ b/langs/en-US/foxbot.ftl
@@ -108,6 +108,8 @@ automatic-preview-disable = Sourced image previews disabled.
 automatic-preview-enable = Sourced image previews enabled.
 automatic-album-enable = In-group album sourcing enabled.
 automatic-album-disable = In-group album sourcing disabled.
+automatic-sources-link = I've collected the sources here: { $link }
+automatic-image-number = Image { $number }
 
 # Error Messages
 error-generic = Oh no, something went wrong! Please send a message to my creator, { -creatorName }, saying what happened.

--- a/langs/en-US/foxbot.ftl
+++ b/langs/en-US/foxbot.ftl
@@ -106,8 +106,8 @@ automatic-disable = This feature is now turned off.
 automatic-enable-not-group = This feature is only supported in groups.
 automatic-preview-disable = Sourced image previews disabled.
 automatic-preview-enable = Sourced image previews enabled.
-automatic-album-enable = Album sourcing enabled.
-automatic-album-disable = Album sourcing disabled.
+automatic-album-enable = In-group album sourcing enabled.
+automatic-album-disable = In-group album sourcing disabled.
 
 # Error Messages
 error-generic = Oh no, something went wrong! Please send a message to my creator, { -creatorName }, saying what happened.

--- a/migrations/20210527025817_media_group_storage.sql
+++ b/migrations/20210527025817_media_group_storage.sql
@@ -1,0 +1,9 @@
+CREATE TABLE media_group (
+    id SERIAL PRIMARY KEY,
+    media_group_id TEXT NOT NULL,
+    inserted_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    message JSONB NOT NULL,
+    sources JSONB
+);
+
+CREATE INDEX media_group_media_group_id_idx ON media_group (media_group_id);

--- a/migrations/20210527025817_media_group_storage.sql
+++ b/migrations/20210527025817_media_group_storage.sql
@@ -7,3 +7,7 @@ CREATE TABLE media_group (
 );
 
 CREATE INDEX media_group_media_group_id_idx ON media_group (media_group_id);
+
+CREATE TABLE media_group_sent (
+    media_group_id TEXT PRIMARY KEY
+);

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -265,6 +265,18 @@
       ]
     }
   },
+  "4888531be643a4e44919519751b084b3c91d0a577e98a3d79e71be194364d94b": {
+    "query": "INSERT INTO media_group_sent (media_group_id) VALUES ($1) ON CONFLICT DO NOTHING",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "4bf1e2603910e4ef6f67ad369260e0dc3b903787e0f95bfaf84a74123c652132": {
     "query": "SELECT id, processed, source, url, mp4_url, thumb_url, display_url, display_name, job_id\n            FROM videos\n            WHERE display_name = $1",
     "describe": {
@@ -331,6 +343,18 @@
         false,
         true
       ]
+    }
+  },
+  "4d2d1d5730b30c4d12f6565fdce3d106630c208dab16eb78e340f10e4af74486": {
+    "query": "DELETE FROM media_group_sent WHERE media_group_id = $1",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      },
+      "nullable": []
     }
   },
   "53b1a22850cc91a5b580980621b27c50dfe69ced32161317a31dfdb8d75ee53e": {
@@ -810,6 +834,18 @@
       "nullable": []
     }
   },
+  "c4121241eeaae9aeb31f32f1a6e885fb65b9ea74f7d98335865d32663f0c8cf4": {
+    "query": "DELETE FROM media_group WHERE media_group_id = $1",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "ccbff78ccf9a1a19a65a95d192ccb1ead5dbe14e9ca611014651c950c466ff92": {
     "query": "INSERT INTO twitter_auth (account_id, request_key, request_secret) VALUES\n                (lookup_account_by_telegram_id($1), $2, $3)",
     "describe": {
@@ -858,6 +894,44 @@
         ]
       },
       "nullable": []
+    }
+  },
+  "f024583958ea5c80459dfd5679bb8b44e2a08367a48be9e25bc67eebeac50cb9": {
+    "query": "SELECT id, inserted_at, message, sources FROM media_group WHERE media_group_id = $1",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "inserted_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 2,
+          "name": "message",
+          "type_info": "Jsonb"
+        },
+        {
+          "ordinal": 3,
+          "name": "sources",
+          "type_info": "Jsonb"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        true
+      ]
     }
   },
   "f78fdca94944e40d61b918c5db894566061ea7ac380c3475bc7cc67471edabf7": {

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -1,5 +1,27 @@
 {
   "db": "PostgreSQL",
+  "0029a3f84dbfc1a1ca301cefd10cc53167f290619591fc3d509129027ee49e8d": {
+    "query": "INSERT INTO media_group (media_group_id, inserted_at, message) VALUES ($1, $2, $3) RETURNING id",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Timestamptz",
+          "Jsonb"
+        ]
+      },
+      "nullable": [
+        false
+      ]
+    }
+  },
   "04f264317ab6180a39bf2733b43f40e61a2c3b0add97be42d474e3fa1d03af04": {
     "query": "SELECT value\n            FROM group_config\n            WHERE group_config.chat_id = lookup_chat_by_telegram_id($1) AND name = $2\n            ORDER BY updated_at DESC LIMIT 1",
     "describe": {
@@ -61,6 +83,44 @@
         ]
       },
       "nullable": []
+    }
+  },
+  "1ef65794d39e8a7b34439d241831ecd2696f80d8d9e49920e30e4ccc754138a4": {
+    "query": "DELETE FROM media_group WHERE media_group_id = $1 RETURNING id, inserted_at, message, sources",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "inserted_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 2,
+          "name": "message",
+          "type_info": "Jsonb"
+        },
+        {
+          "ordinal": 3,
+          "name": "sources",
+          "type_info": "Jsonb"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        true
+      ]
     }
   },
   "2d0eb75f282ed83d99e5ef77e8344bb6727742454c9f42b9cf1a9ceab5988e90": {
@@ -496,6 +556,26 @@
       "nullable": []
     }
   },
+  "7cef969e5789cdf8338c5c592de8850c5305f68f5bf544644322a132a613c4a7": {
+    "query": "SELECT max(inserted_at) FROM media_group WHERE media_group_id = $1",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "max",
+          "type_info": "Timestamptz"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      },
+      "nullable": [
+        null
+      ]
+    }
+  },
   "7f9bdd51e9430d93edebd6180a5ac2ad0d7172ebaf5bab5bffd44d447771518a": {
     "query": "UPDATE videos SET job_id = $1 WHERE id = $2",
     "describe": {
@@ -641,6 +721,57 @@
         ]
       },
       "nullable": []
+    }
+  },
+  "afd66774f549521d1689b2e0934601a95976b034f9fde713b66f4fd21b827a62": {
+    "query": "UPDATE media_group SET sources = $1 WHERE id = $2",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Jsonb",
+          "Int4"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "b80505d9c0c51124ba42946e0c36ad1773e109e9eefed1cc7b46e5ac7ba19d23": {
+    "query": "SELECT id, inserted_at, message, sources FROM media_group WHERE id = $1",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "inserted_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 2,
+          "name": "message",
+          "type_info": "Jsonb"
+        },
+        {
+          "ordinal": 3,
+          "name": "sources",
+          "type_info": "Jsonb"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int4"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        true
+      ]
     }
   },
   "be823b9738decf3ac8c9f0574a984a5ee07829a4b67241a567687d92a2f0b76e": {

--- a/templates/mediagroup.hbs
+++ b/templates/mediagroup.hbs
@@ -1,0 +1,47 @@
+{{#*inline "page"}}
+<h1>Media Group Sources</h1>
+
+{{#if items}}
+<p>
+    This page will only exist for around 24 hours after it's creation.
+</p>
+{{/if}}
+
+<style>
+    img {
+        display: inline-block;
+        max-width: 100%;
+    }
+
+    ul {
+        padding: 0;
+        -webkit-padding-start: 0;
+    }
+</style>
+
+{{#each items as |item|}}
+    <section>
+        <p>
+            <img src="{{@root.cdn_url}}/{{@root.cdn_bucket}}/mg/{{item.media_group_id}}/{{item.file_id}}">
+        </p>
+
+        <ul>
+            {{#each item.urls as |url|}}
+                <li><a href="{{url}}">{{url}}</a></li>
+            {{else}}
+                <li>No matches found</li>
+            {{/each}}
+        </ul>
+    </section>
+{{else}}
+    <p>
+        No items were found. It's likely the content here was already deleted.
+    </p>
+
+    <p>
+        Try forwarding the images you're interested in to <a href="https://t.me/FoxBot">@FoxBot</a> directly.
+    </p>
+{{/each}}
+{{/inline}}
+
+{{~> base }}


### PR DESCRIPTION
Currently, if automatic sourcing is enabled, and a user posts a media group, the bot will reply to each image in the media group. This is undesirable as it can create a lot of messages. This PR temporarily stores messages in the database until 10 seconds have passed since the most recent message in the group, then replies with a single message with sources for all images in the group.

Closes #47. 