### PR TITLE
Collect more site info, optionally add to inline responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52fb27eab85b17fbb9f6fd667089e07d6a2eb8743d02639ee7f6a7a7729c9c94"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -615,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6cb3c7f5b8e51bc3ebb73a2327ad4abdbd119dc13223f14f961d2f38486756"
+checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -625,11 +625,10 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "autocfg",
  "cfg-if",
  "lazy_static",
 ]
@@ -1093,6 +1092,7 @@ dependencies = [
  "async-trait",
  "egg-mode",
  "foxbot-models",
+ "furaffinity-rs",
  "futures",
  "fuzzysearch",
  "regex",
@@ -1147,6 +1147,22 @@ name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+
+[[package]]
+name = "furaffinity-rs"
+version = "0.1.0"
+source = "git+https://github.com/Syfaro/furaffinity-rs?branch=main#9825e488e7c6737686e5f95dbcb56146aea6382e"
+dependencies = [
+ "chrono",
+ "image",
+ "img_hash",
+ "lazy_static",
+ "regex",
+ "reqwest",
+ "scraper",
+ "sha2",
+ "thiserror",
+]
 
 [[package]]
 name = "futf"

--- a/foxbot-sites/Cargo.toml
+++ b/foxbot-sites/Cargo.toml
@@ -26,5 +26,6 @@ egg-mode = { git = "https://github.com/egg-mode-rs/egg-mode" }
 scraper = "0.12"
 
 fuzzysearch = { git = "https://github.com/Syfaro/fuzzysearch-rs", features = ["trace", "local_hash"] }
+furaffinity-rs = { git = "https://github.com/Syfaro/furaffinity-rs", branch = "main" }
 
 foxbot-models = { path = "../foxbot-models" }

--- a/foxbot-utils/src/lib.rs
+++ b/foxbot-utils/src/lib.rs
@@ -253,7 +253,7 @@ pub async fn size_post(post: &PostInfo, data: &bytes::Bytes) -> anyhow::Result<P
 /// Download URL from post, calculate image dimensions, convert to JPEG and
 /// generate thumbnail, and upload to S3 bucket. Returns a new PostInfo with
 /// the updated URLs and dimensions.
-#[tracing::instrument(err, skip(conn, s3, s3_bucket, s3_url, data))]
+#[tracing::instrument(err, skip(conn, s3, s3_bucket, s3_url, data, post), fields(post_url = %post.url))]
 pub async fn cache_post(
     conn: &sqlx::Pool<sqlx::Postgres>,
     s3: &rusoto_s3::S3Client,


### PR DESCRIPTION
Closes #83 by collecting title, artist, and tags from sites which support it. Adds the completely undiscoverable but useful for testing feature of allowing their inclusion in inline responses using the `#info` or `#tags` hashtags in the inline query.