### PR TITLE
Coconut API v2, send larger videos as messages

### DIFF
--- a/langs/en-US/foxbot.ftl
+++ b/langs/en-US/foxbot.ftl
@@ -44,13 +44,15 @@ inline-no-results-body = I could not find any results for the provided query.
 
 # Inline Results Misc
 inline-help = Help
-inline-process = Process Video
 
 # Inline Videos
+inline-process = Process Video
+inline-large-video = Get Large Video
 video-starting = Starting to process video...
 video-progress = Video processing is { $percent } complete...
 video-finished = Finished transcoding, uploading video...
 video-return-button = Return and send
+video-too-large = Sorry, this video is too large to send inline. I'll send you the video to forward instead.
 video-unknown = Sorry, something went wrong.
 
 # Reverse Search

--- a/migrations/20220127013410_large_videos.sql
+++ b/migrations/20220127013410_large_videos.sql
@@ -1,0 +1,14 @@
+TRUNCATE TABLE videos CASCADE;
+
+ALTER TABLE
+    videos RENAME TO video;
+
+ALTER TABLE
+    video
+ADD
+    COLUMN file_size integer;
+
+ALTER TABLE
+    video
+ALTER COLUMN
+    job_id TYPE text;

--- a/migrations/20220127013410_large_videos.sql
+++ b/migrations/20220127013410_large_videos.sql
@@ -6,7 +6,13 @@ ALTER TABLE
 ALTER TABLE
     video
 ADD
-    COLUMN file_size integer;
+    COLUMN file_size integer,
+ADD
+    COLUMN height integer,
+ADD
+    COLUMN width integer,
+ADD
+    COLUMN duration integer;
 
 ALTER TABLE
     video

--- a/queries/video/insert_media.sql
+++ b/queries/video/insert_media.sql
@@ -1,5 +1,5 @@
 INSERT INTO
-    videos (source, url, display_url, display_name)
+    video (source, url, display_url, display_name)
 VALUES
     ($1, $2, $3, $4) ON CONFLICT ON CONSTRAINT unique_source DO
 UPDATE

--- a/queries/video/lookup_by_display_name.sql
+++ b/queries/video/lookup_by_display_name.sql
@@ -1,6 +1,6 @@
 SELECT
     *
 FROM
-    videos
+    video
 WHERE
     display_name = $1;

--- a/queries/video/lookup_by_url_id.sql
+++ b/queries/video/lookup_by_url_id.sql
@@ -1,6 +1,6 @@
 SELECT
     *
 FROM
-    videos
+    video
 WHERE
     source = $1;

--- a/queries/video/set_job_id.sql
+++ b/queries/video/set_job_id.sql
@@ -1,5 +1,5 @@
 UPDATE
-    videos
+    video
 SET
     job_id = $2
 WHERE

--- a/queries/video/set_processed_url.sql
+++ b/queries/video/set_processed_url.sql
@@ -1,8 +1,9 @@
 UPDATE
-    videos
+    video
 SET
     processed = true,
     mp4_url = $2,
-    thumb_url = $3
+    thumb_url = $3,
+    file_size = $4
 WHERE
     id = $1;

--- a/queries/video/set_processed_url.sql
+++ b/queries/video/set_processed_url.sql
@@ -4,6 +4,8 @@ SET
     processed = true,
     mp4_url = $2,
     thumb_url = $3,
-    file_size = $4
+    file_size = $4,
+    height = $5,
+    width = $6
 WHERE
     id = $1;

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -383,6 +383,23 @@
       ]
     }
   },
+  "5d1591229aaa5d421ccff6a9048c98a5daee62206f0de987d7cc9ab39a28d019": {
+    "query": "UPDATE\n    video\nSET\n    processed = true,\n    mp4_url = $2,\n    thumb_url = $3,\n    file_size = $4,\n    height = $5,\n    width = $6\nWHERE\n    id = $1;\n",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Int4",
+          "Text",
+          "Text",
+          "Int4",
+          "Int4",
+          "Int4"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "5e7c827d28f612561908b4bde50b77a5edfb4e421d024ca1f139c06e38c30f02": {
     "query": "DELETE FROM\n    chat_administrator\nWHERE\n    chat_id = lookup_chat_by_telegram_id($1)\n    AND account_id <> lookup_account_by_telegram_id($2);\n",
     "describe": {
@@ -485,21 +502,6 @@
       "parameters": {
         "Left": [
           "Int4",
-          "Int4"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "84819440cc07ba79645c12cc641981e6a545af5ff13213bfd374a668f0cd1555": {
-    "query": "UPDATE\n    video\nSET\n    processed = true,\n    mp4_url = $2,\n    thumb_url = $3,\n    file_size = $4\nWHERE\n    id = $1;\n",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Int4",
-          "Text",
-          "Text",
           "Int4"
         ]
       },
@@ -622,6 +624,21 @@
           "ordinal": 10,
           "name": "file_size",
           "type_info": "Int4"
+        },
+        {
+          "ordinal": 11,
+          "name": "height",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 12,
+          "name": "width",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 13,
+          "name": "duration",
+          "type_info": "Int4"
         }
       ],
       "parameters": {
@@ -640,6 +657,9 @@
         true,
         false,
         false,
+        true,
+        true,
+        true,
         true
       ]
     }
@@ -803,6 +823,21 @@
           "ordinal": 10,
           "name": "file_size",
           "type_info": "Int4"
+        },
+        {
+          "ordinal": 11,
+          "name": "height",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 12,
+          "name": "width",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 13,
+          "name": "duration",
+          "type_info": "Int4"
         }
       ],
       "parameters": {
@@ -821,6 +856,9 @@
         true,
         false,
         false,
+        true,
+        true,
+        true,
         true
       ]
     }

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -147,17 +147,27 @@
       ]
     }
   },
-  "277cd2d0ce7931d5251e3157221461f2d16d3812c16abd19e7eec060f5218228": {
-    "query": "UPDATE\n    videos\nSET\n    job_id = $2\nWHERE\n    id = $1;\n",
+  "22676f44ecfedb9cfe9208523886d6d3b95a8722044fa0864f539707540f6fec": {
+    "query": "INSERT INTO\n    video (source, url, display_url, display_name)\nVALUES\n    ($1, $2, $3, $4) ON CONFLICT ON CONSTRAINT unique_source DO\nUPDATE\nSET\n    source = EXCLUDED.source RETURNING display_name;\n",
     "describe": {
-      "columns": [],
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "display_name",
+          "type_info": "Text"
+        }
+      ],
       "parameters": {
         "Left": [
-          "Int4",
-          "Int4"
+          "Text",
+          "Text",
+          "Text",
+          "Text"
         ]
       },
-      "nullable": []
+      "nullable": [
+        false
+      ]
     }
   },
   "2a28a8e1cf8fdcc9418fabca881b0a684c80d2a54672f3ce463e26a8518c0b73": {
@@ -406,29 +416,6 @@
       ]
     }
   },
-  "6d808b6df56b8f154ae8e2c36ad11a80ddd2b2efed857b2dab516fa826051885": {
-    "query": "INSERT INTO\n    videos (source, url, display_url, display_name)\nVALUES\n    ($1, $2, $3, $4) ON CONFLICT ON CONSTRAINT unique_source DO\nUPDATE\nSET\n    source = EXCLUDED.source RETURNING display_name;\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "display_name",
-          "type_info": "Text"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Text",
-          "Text",
-          "Text",
-          "Text"
-        ]
-      },
-      "nullable": [
-        false
-      ]
-    }
-  },
   "753f8ee016949fd8ddb14f012fc6195a8299556d61ef3f41e9efc9242bcca751": {
     "query": "INSERT INTO\n    group_config (chat_id, name, value)\nVALUES\n    (lookup_chat($1, $2), $3, $4);\n",
     "describe": {
@@ -504,6 +491,21 @@
       "nullable": []
     }
   },
+  "84819440cc07ba79645c12cc641981e6a545af5ff13213bfd374a668f0cd1555": {
+    "query": "UPDATE\n    video\nSET\n    processed = true,\n    mp4_url = $2,\n    thumb_url = $3,\n    file_size = $4\nWHERE\n    id = $1;\n",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Int4",
+          "Text",
+          "Text",
+          "Int4"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "8659ef85b33eab9fee0f5457ff38741ec1c450086688e91c12ae71c9a096f9c9": {
     "query": "INSERT INTO\n    permission (chat_id, updated_at, permissions)\nVALUES\n    (\n        lookup_chat_by_telegram_id($1),\n        to_timestamp($2::int),\n        $3\n    );\n",
     "describe": {
@@ -556,6 +558,86 @@
       "nullable": [
         false,
         false,
+        false,
+        false,
+        true
+      ]
+    }
+  },
+  "89ef02c50a0dfb3227c159052c7feb22d07df036927fa453d4227a4e780d24c1": {
+    "query": "SELECT\n    *\nFROM\n    video\nWHERE\n    source = $1;\n",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "processed",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 2,
+          "name": "source",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 3,
+          "name": "url",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 4,
+          "name": "mp4_url",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 5,
+          "name": "job_id",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 6,
+          "name": "display_name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 7,
+          "name": "thumb_url",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 8,
+          "name": "display_url",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 9,
+          "name": "created_at",
+          "type_info": "Timestamp"
+        },
+        {
+          "ordinal": 10,
+          "name": "file_size",
+          "type_info": "Int4"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        false,
+        true,
         false,
         false,
         true
@@ -650,8 +732,21 @@
       ]
     }
   },
-  "9edd1f5a215cb4e4469fb9c28bb90ced55523a37a1a78a305d592ee563674127": {
-    "query": "SELECT\n    *\nFROM\n    videos\nWHERE\n    display_name = $1;\n",
+  "a0f682ace9eb7237d4bf0f4aff4a4e052c5fe7f38c7cf5519ad09455f22b819e": {
+    "query": "UPDATE\n    media_group\nSET\n    sources = $2\nWHERE\n    id = $1;\n",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Int4",
+          "Jsonb"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "b1edf542e68e59a16e623dec6328b93591c7406dde484d42b2a749da787ff7d9": {
+    "query": "SELECT\n    *\nFROM\n    video\nWHERE\n    display_name = $1;\n",
     "describe": {
       "columns": [
         {
@@ -682,7 +777,7 @@
         {
           "ordinal": 5,
           "name": "job_id",
-          "type_info": "Int4"
+          "type_info": "Text"
         },
         {
           "ordinal": 6,
@@ -703,6 +798,11 @@
           "ordinal": 9,
           "name": "created_at",
           "type_info": "Timestamp"
+        },
+        {
+          "ordinal": 10,
+          "name": "file_size",
+          "type_info": "Int4"
         }
       ],
       "parameters": {
@@ -720,21 +820,9 @@
         false,
         true,
         false,
-        false
+        false,
+        true
       ]
-    }
-  },
-  "a0f682ace9eb7237d4bf0f4aff4a4e052c5fe7f38c7cf5519ad09455f22b819e": {
-    "query": "UPDATE\n    media_group\nSET\n    sources = $2\nWHERE\n    id = $1;\n",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Int4",
-          "Jsonb"
-        ]
-      },
-      "nullable": []
     }
   },
   "b46ec3cb829d9c4570750007e5e605d38dfece964401e4047313713e16c83d85": {
@@ -818,80 +906,6 @@
         ]
       },
       "nullable": []
-    }
-  },
-  "c5c45d309e427da06209ceb93b7ede2c29bc283a33178f3ac354bd87b8f8e3ee": {
-    "query": "SELECT\n    *\nFROM\n    videos\nWHERE\n    source = $1;\n",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Int4"
-        },
-        {
-          "ordinal": 1,
-          "name": "processed",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 2,
-          "name": "source",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 3,
-          "name": "url",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 4,
-          "name": "mp4_url",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 5,
-          "name": "job_id",
-          "type_info": "Int4"
-        },
-        {
-          "ordinal": 6,
-          "name": "display_name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 7,
-          "name": "thumb_url",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 8,
-          "name": "display_url",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 9,
-          "name": "created_at",
-          "type_info": "Timestamp"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Text"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        true,
-        true,
-        false,
-        true,
-        false,
-        false
-      ]
     }
   },
   "c5f253419b3064b904e7781519656444e574a94633242eea343a958f00c308e0": {
@@ -993,6 +1007,19 @@
       ]
     }
   },
+  "e86dfc0d56977713d6c2ff7f4fcb404fdb0b442b7f68694f39ae86d451a3d4a7": {
+    "query": "UPDATE\n    video\nSET\n    job_id = $2\nWHERE\n    id = $1;\n",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Int4",
+          "Text"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "e8d51adb623c232c5c28a7e12acef9d543e01fb4f78dda2ccbb3102350e92271": {
     "query": "INSERT INTO\n    video_job_message (video_id, chat_id, message_id)\nVALUES\n    ($1, lookup_chat($2, $3), $4);\n",
     "describe": {
@@ -1003,20 +1030,6 @@
           "Int8",
           "Numeric",
           "Int4"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "eaa76525f74cb03761ae9ea58dc66d652e650d0c24b6ba3f36db17d9933d5195": {
-    "query": "UPDATE\n    videos\nSET\n    processed = true,\n    mp4_url = $2,\n    thumb_url = $3\nWHERE\n    id = $1;\n",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Int4",
-          "Text",
-          "Text"
         ]
       },
       "nullable": []

--- a/src/execute/discord/mod.rs
+++ b/src/execute/discord/mod.rs
@@ -144,6 +144,7 @@ struct Context {
     fuzzysearch: std::sync::Arc<fuzzysearch::FuzzySearch>,
 }
 
+#[allow(clippy::single_match)]
 #[tracing::instrument(err, skip(event, ctx))]
 async fn handle_event(event: Event, ctx: Context) -> anyhow::Result<()> {
     tracing::trace!("Got event: {:?}", event);

--- a/src/execute/telegram/handlers/commands.rs
+++ b/src/execute/telegram/handlers/commands.rs
@@ -347,7 +347,7 @@ impl CommandHandler {
 
             utils::match_image(&cx.bot, &cx.redis, &cx.fuzzysearch, best_photo, Some(10)).await?
         } else {
-            let from = message.from.as_ref().ok_or(Error::Missing)?;
+            let from = message.from.as_ref().ok_or(Error::missing("user"))?;
 
             let links = utils::extract_links(message);
 

--- a/src/execute/telegram/handlers/commands.rs
+++ b/src/execute/telegram/handlers/commands.rs
@@ -79,7 +79,10 @@ impl Handler for CommandHandler {
 
 impl CommandHandler {
     async fn handle_mirror(&self, cx: &Context, message: &tgbotapi::Message) -> Result<(), Error> {
-        let from = message.from.as_ref().unwrap();
+        let from = message
+            .from
+            .as_ref()
+            .ok_or_else(|| Error::missing("user"))?;
 
         let action = utils::continuous_action(
             cx.bot.clone(),
@@ -347,7 +350,10 @@ impl CommandHandler {
 
             utils::match_image(&cx.bot, &cx.redis, &cx.fuzzysearch, best_photo, Some(10)).await?
         } else {
-            let from = message.from.as_ref().ok_or(Error::missing("user"))?;
+            let from = message
+                .from
+                .as_ref()
+                .ok_or_else(|| Error::missing("user"))?;
 
             let links = utils::extract_links(message);
 

--- a/src/execute/telegram/handlers/inline_handler.rs
+++ b/src/execute/telegram/handlers/inline_handler.rs
@@ -633,7 +633,7 @@ async fn video_complete(
         }
 
         if let Err(err) = send_previous_video(
-            &cx,
+            cx,
             &sent_as,
             message.0.into(),
             reply_markup.clone(),
@@ -1096,6 +1096,7 @@ fn build_gif_result(
     results
 }
 
+#[allow(clippy::manual_map)]
 fn find_sent_as(message: &tgbotapi::Message) -> Option<SentAs> {
     if let Some(video) = &message.video {
         Some(SentAs::Video(video.file_id.clone()))

--- a/src/execute/telegram/handlers/twitter.rs
+++ b/src/execute/telegram/handlers/twitter.rs
@@ -27,7 +27,7 @@ impl Handler for TwitterHandler {
                     twitter_username,
                 } = account;
 
-                let telegram_id = telegram_id.ok_or(Error::Missing)?;
+                let telegram_id = telegram_id.ok_or(Error::missing("telegram id"))?;
 
                 let mut args = FluentArgs::new();
                 args.set("userName", twitter_username);

--- a/src/execute/telegram/handlers/twitter.rs
+++ b/src/execute/telegram/handlers/twitter.rs
@@ -27,7 +27,7 @@ impl Handler for TwitterHandler {
                     twitter_username,
                 } = account;
 
-                let telegram_id = telegram_id.ok_or(Error::missing("telegram id"))?;
+                let telegram_id = telegram_id.ok_or_else(|| Error::missing("telegram id"))?;
 
                 let mut args = FluentArgs::new();
                 args.set("userName", twitter_username);

--- a/src/execute/telegram/jobs/channel.rs
+++ b/src/execute/telegram/jobs/channel.rs
@@ -36,7 +36,7 @@ pub async fn process_channel_update(
         );
     }
 
-    let file = utils::find_best_photo(sizes).ok_or(Error::Missing)?;
+    let file = utils::find_best_photo(sizes).ok_or(Error::missing("channel update photo"))?;
     let (searched_hash, mut matches) =
         utils::match_image(&cx.bot, &cx.redis, &cx.fuzzysearch, file, Some(3)).await?;
 

--- a/src/execute/telegram/jobs/channel.rs
+++ b/src/execute/telegram/jobs/channel.rs
@@ -36,7 +36,8 @@ pub async fn process_channel_update(
         );
     }
 
-    let file = utils::find_best_photo(sizes).ok_or(Error::missing("channel update photo"))?;
+    let file =
+        utils::find_best_photo(sizes).ok_or_else(|| Error::missing("channel update photo"))?;
     let (searched_hash, mut matches) =
         utils::match_image(&cx.bot, &cx.redis, &cx.fuzzysearch, file, Some(3)).await?;
 

--- a/src/execute/telegram/jobs/mod.rs
+++ b/src/execute/telegram/jobs/mod.rs
@@ -265,6 +265,9 @@ pub enum CoconutEventJob {
         video_url: String,
         thumb_url: String,
         video_size: i32,
+        duration: i32,
+        height: i32,
+        width: i32,
     },
     Failed {
         display_name: String,

--- a/src/execute/telegram/jobs/mod.rs
+++ b/src/execute/telegram/jobs/mod.rs
@@ -264,6 +264,10 @@ pub enum CoconutEventJob {
         display_name: String,
         video_url: String,
         thumb_url: String,
+        video_size: i32,
+    },
+    Failed {
+        display_name: String,
     },
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,8 +249,8 @@ pub enum Error {
     Bot(Cow<'static, str>),
     #[error("limit exceeded: {0}")]
     Limit(Cow<'static, str>),
-    #[error("essential data was missing")]
-    Missing,
+    #[error("essential data was missing: {0}")]
+    Missing(Cow<'static, str>),
 
     #[error("{message}")]
     UserMessage {
@@ -272,6 +272,13 @@ impl Error {
         M: Into<Cow<'static, str>>,
     {
         Self::Limit(name.into())
+    }
+
+    pub fn missing<M>(data: M) -> Self
+    where
+        M: Into<Cow<'static, str>>,
+    {
+        Self::Missing(data.into())
     }
 
     pub fn user_message<M>(message: M) -> Self
@@ -309,7 +316,7 @@ pub trait ErrorMetadata {
 
 impl ErrorMetadata for Error {
     fn is_retryable(&self) -> bool {
-        matches!(self, Error::Missing)
+        matches!(self, Error::Missing(_))
     }
 
     fn user_message(&self) -> Option<&str> {

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -538,7 +538,10 @@ impl MediaGroup {
         executor: E,
         message: &tgbotapi::Message,
     ) -> Result<i32, Error> {
-        let media_group_id = message.media_group_id.as_ref().ok_or(Error::Missing)?;
+        let media_group_id = message
+            .media_group_id
+            .as_ref()
+            .ok_or(Error::missing("media group id"))?;
 
         let id = sqlx::query_file_scalar!(
             "queries/media_group/add_message.sql",
@@ -654,11 +657,12 @@ pub struct Video {
     pub source: String,
     pub url: String,
     pub mp4_url: Option<String>,
-    pub job_id: Option<i32>,
+    pub job_id: Option<String>,
     pub display_name: String,
     pub thumb_url: Option<String>,
     pub display_url: String,
     pub created_at: chrono::NaiveDateTime,
+    pub file_size: Option<i32>,
 }
 
 impl Video {
@@ -711,7 +715,7 @@ impl Video {
     pub async fn set_job_id<'a, E: PgExecutor<'a>>(
         executor: E,
         id: i32,
-        job_id: i32,
+        job_id: &str,
     ) -> Result<(), Error> {
         sqlx::query_file!("queries/video/set_job_id.sql", id, job_id)
             .execute(executor)
@@ -725,12 +729,14 @@ impl Video {
         id: i32,
         mp4_url: &str,
         thumb_url: &str,
+        file_size: i32,
     ) -> Result<(), Error> {
         sqlx::query_file!(
             "queries/video/set_processed_url.sql",
             id,
             mp4_url,
-            thumb_url
+            thumb_url,
+            file_size
         )
         .execute(executor)
         .await?;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -541,7 +541,7 @@ impl MediaGroup {
         let media_group_id = message
             .media_group_id
             .as_ref()
-            .ok_or(Error::missing("media group id"))?;
+            .ok_or_else(|| Error::missing("media group id"))?;
 
         let id = sqlx::query_file_scalar!(
             "queries/media_group/add_message.sql",

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -663,6 +663,9 @@ pub struct Video {
     pub display_url: String,
     pub created_at: chrono::NaiveDateTime,
     pub file_size: Option<i32>,
+    pub height: Option<i32>,
+    pub width: Option<i32>,
+    pub duration: Option<i32>,
 }
 
 impl Video {
@@ -730,13 +733,17 @@ impl Video {
         mp4_url: &str,
         thumb_url: &str,
         file_size: i32,
+        height: i32,
+        width: i32,
     ) -> Result<(), Error> {
         sqlx::query_file!(
             "queries/video/set_processed_url.sql",
             id,
             mp4_url,
             thumb_url,
-            file_size
+            file_size,
+            height,
+            width
         )
         .execute(executor)
         .await?;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -27,6 +27,7 @@ pub enum User {
 }
 
 impl User {
+    #[allow(clippy::manual_map)]
     pub fn from_one(telegram_id: Option<i64>, discord_id: Option<BigDecimal>) -> Option<Self> {
         if let Some(id) = telegram_id {
             Some(Self::Telegram(id))

--- a/src/services/coconut.rs
+++ b/src/services/coconut.rs
@@ -59,13 +59,14 @@ impl Coconut {
 
         let id = json
             .get("id")
-            .ok_or(Error::missing("job id"))?
+            .ok_or_else(|| Error::missing("job id"))?
             .as_str()
-            .ok_or(Error::missing("job id as str"))?;
+            .ok_or_else(|| Error::missing("job id as str"))?;
 
         Ok(id.to_owned())
     }
 
+    /// Create a Coconut request where the encoded video can be at most 50MB.
     fn build_config(&self, source: &str, name: &str) -> serde_json::Value {
         serde_json::json!({
             "input": {
@@ -94,19 +95,20 @@ impl Coconut {
                 },
                 "mp4:1080p": {
                     "path": format!("/video/{}.mp4", name),
-                    "if": "{{ input.duration }} <= 60",
+                    "if": "{{ input.duration }} <= 100",
                 },
                 "mp4:720p": {
                     "path": format!("/video/{}.mp4", name),
-                    "if": "{{ input.duration }} <= 120 and {{ input.duration }} > 60",
+                    "if": "{{ input.duration }} <= 200 and {{ input.duration }} > 100",
                 },
                 "mp4:480p": {
                     "path": format!("/video/{}.mp4", name),
-                    "if": "{{ input.duration }} <= 180 and {{ input.duration }} > 120",
+                    "if": "{{ input.duration }} <= 400 and {{ input.duration }} > 200",
                 },
                 "mp4:360p": {
                     "path": format!("/video/{}.mp4", name),
-                    "if": "{{ input.duration }} > 180"
+                    "if": "{{ input.duration }} > 400",
+                    "duration": 500,
                 }
             }
         })

--- a/src/services/coconut.rs
+++ b/src/services/coconut.rs
@@ -11,7 +11,7 @@ pub struct Coconut {
 }
 
 impl Coconut {
-    const COCONUT_API_ENDPOINT: &'static str = "https://api.coconut.co/v1/jobs";
+    const COCONUT_API_ENDPOINT: &'static str = "https://api.coconut.co/v2/jobs";
 
     pub fn new(
         api_token: String,
@@ -33,14 +33,14 @@ impl Coconut {
         }
     }
 
-    pub async fn start_video(&self, source: &str, name: &str) -> Result<i32, Error> {
+    pub async fn start_video(&self, source: &str, name: &str) -> Result<String, Error> {
         let config = self.build_config(source, name);
 
         let resp = self
             .client
             .post(Self::COCONUT_API_ENDPOINT)
             .basic_auth(&self.api_token, None::<&str>)
-            .body(config)
+            .json(&config)
             .send()
             .await?;
 
@@ -59,36 +59,56 @@ impl Coconut {
 
         let id = json
             .get("id")
-            .ok_or(Error::Missing)?
-            .as_i64()
-            .ok_or(Error::Missing)?;
-        Ok(id as i32)
+            .ok_or(Error::missing("job id"))?
+            .as_str()
+            .ok_or(Error::missing("job id as str"))?;
+
+        Ok(id.to_owned())
     }
 
-    fn build_config(&self, source: &str, name: &str) -> String {
-        format!(
-            "
-            var account_id = {account_id}
-            var app_key = {app_key}
-            var bucket_id = {bucket_id}
-            var cdn = b2://$account_id:$app_key@$bucket_id
-
-            # Settings
-            set source = {source}
-            set webhook = {webhook}?name={name}, events=true
-
-            # Outputs
-            -> mp4:720p = $cdn/video/{name}.mp4, if=$source_duration <= 60
-            -> mp4:480p = $cdn/video/{name}.mp4, if=$source_duration <= 120 AND $source_duration > 60
-            -> mp4:360p = $cdn/video/{name}.mp4, if=$source_duration > 120, duration = 150
-            -> jpg:250x0 = $cdn/thumbnail/{name}.jpg, number=1
-        ",
-            account_id = self.b2_account_id,
-            app_key = self.b2_app_key,
-            bucket_id = self.b2_bucket_id,
-            source = source,
-            webhook = self.webhook,
-            name = name
-        )
+    fn build_config(&self, source: &str, name: &str) -> serde_json::Value {
+        serde_json::json!({
+            "input": {
+                "url": source,
+            },
+            "storage": {
+                "service": "backblaze",
+                "bucket_id": self.b2_bucket_id,
+                "credentials": {
+                    "app_key_id": self.b2_account_id,
+                    "app_key": self.b2_app_key,
+                }
+            },
+            "notification": {
+                "type": "http",
+                "url": self.webhook,
+                "events": true,
+                "metadata": true,
+                "params": {
+                    "name": name,
+                }
+            },
+            "outputs": {
+                "jpg:250x0": {
+                    "path": format!("/thumbnail/{}.jpg", name),
+                },
+                "mp4:1080p": {
+                    "path": format!("/video/{}.mp4", name),
+                    "if": "{{ input.duration }} <= 60",
+                },
+                "mp4:720p": {
+                    "path": format!("/video/{}.mp4", name),
+                    "if": "{{ input.duration }} <= 120 and {{ input.duration }} > 60",
+                },
+                "mp4:480p": {
+                    "path": format!("/video/{}.mp4", name),
+                    "if": "{{ input.duration }} <= 180 and {{ input.duration }} > 120",
+                },
+                "mp4:360p": {
+                    "path": format!("/video/{}.mp4", name),
+                    "if": "{{ input.duration }} > 180"
+                }
+            }
+        })
     }
 }

--- a/src/sites/mod.rs
+++ b/src/sites/mod.rs
@@ -153,7 +153,7 @@ impl Direct {
 
         let results = self
             .fautil
-            .image_search(&body, MatchType::Exact, Some(1))
+            .image_search(body, MatchType::Exact, Some(1))
             .await;
 
         match results {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -512,7 +512,7 @@ pub fn chat_from_update(update: &tgbotapi::Update) -> Option<&tgbotapi::Chat> {
 pub fn get_message(bundle: &Bundle, id: &str, args: Option<FluentArgs>) -> String {
     let msg = bundle
         .get_message(id)
-        .ok_or(Error::Missing)
+        .ok_or_else(|| Error::missing("message"))
         .expect("message doesn't exist");
 
     let pattern = msg.value().expect("message has no value");

--- a/src/web.rs
+++ b/src/web.rs
@@ -217,7 +217,7 @@ async fn verify_twitter_account(
     };
 
     let user = models::User::from_one(auth.telegram_id, auth.discord_id)
-        .ok_or(Error::missing("user for twitter"))?;
+        .ok_or_else(|| Error::missing("user for twitter"))?;
 
     let con_token = KeyPair::new(
         config.twitter_consumer_key.clone(),

--- a/src/web.rs
+++ b/src/web.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use actix_web::{web, App, HttpResponse, HttpServer};
 use askama::Template;
 use egg_mode::KeyPair;
@@ -214,7 +216,8 @@ async fn verify_twitter_account(
         None => return Ok(None),
     };
 
-    let user = models::User::from_one(auth.telegram_id, auth.discord_id).ok_or(Error::Missing)?;
+    let user = models::User::from_one(auth.telegram_id, auth.discord_id)
+        .ok_or(Error::missing("user for twitter"))?;
 
     let con_token = KeyPair::new(
         config.twitter_consumer_key.clone(),
@@ -314,29 +317,70 @@ struct CoconutWebHookRequestQuery {
 }
 
 #[derive(Deserialize)]
-struct CoconutWebHookRequestBody {
-    progress: Option<String>,
-    output_urls: Option<CoconutWebHookRequestBodyOutputUrls>,
+#[serde(tag = "event", content = "data")]
+enum CoconutWebHook {
+    #[serde(rename = "input.transferred")]
+    InputTransferred,
+    #[serde(rename = "output.completed")]
+    OutputCompleted { progress: String },
+    #[serde(rename = "job.completed")]
+    JobCompleted { outputs: Vec<CoconutOutput> },
 }
 
 #[derive(Deserialize)]
-struct CoconutWebHookRequestBodyOutputUrls {
-    #[serde(rename = "jpg:250x0")]
-    thumbnail: Vec<String>,
-    #[serde(rename = "mp4:720p")]
-    video_720p: Option<String>,
-    #[serde(rename = "mp4:480p")]
-    video_480p: Option<String>,
-    #[serde(rename = "mp4:360p")]
-    video_360p: Option<String>,
+struct CoconutOutput {
+    key: String,
+    #[serde(flatten)]
+    status: CoconutOutputStatus,
 }
+
+#[derive(Deserialize)]
+#[serde(tag = "status")]
+enum CoconutOutputStatus {
+    #[serde(rename = "video.encoded")]
+    VideoEncoded {
+        #[serde(flatten)]
+        file: CoconutOutputFile,
+    },
+    #[serde(rename = "video.skipped")]
+    VideoSkipped,
+    #[serde(rename = "image.created")]
+    ImageCreated {
+        #[serde(flatten)]
+        file: CoconutOutputFile,
+    },
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+enum CoconutOutputFile {
+    Image {
+        urls: Vec<String>,
+    },
+    Video {
+        url: String,
+        metadata: CoconutMetadata,
+    },
+}
+
+#[derive(Deserialize)]
+struct CoconutMetadata {
+    format: CoconutMetadataFormat,
+}
+
+#[derive(Deserialize)]
+struct CoconutMetadataFormat {
+    size: String,
+}
+
+const COCONUT_FORMATS: &[&str] = &["mp4:1080p", "mp4:720p", "mp4:480p", "mp4:360p"];
 
 async fn coconut_webhook(
     config: web::Data<Config>,
     faktory: web::Data<FaktoryClient>,
     secret: web::Path<String>,
     web::Query(query): web::Query<CoconutWebHookRequestQuery>,
-    data: web::Json<CoconutWebHookRequestBody>,
+    data: web::Json<serde_json::Value>,
 ) -> Result<HttpResponse, actix_web::Error> {
     tracing::info!("got coconut webhook");
 
@@ -345,55 +389,79 @@ async fn coconut_webhook(
         return Ok(HttpResponse::Unauthorized().finish());
     }
 
+    let event: CoconutWebHook = match serde_json::from_value(data.into_inner()) {
+        Ok(data) => data,
+        Err(err) => {
+            tracing::error!("unknown coconut data: {}", err);
+            return Ok(HttpResponse::Ok().body("OK"));
+        }
+    };
+
     let display_name = query.name;
 
-    let job = if let Some(progress) = &data.progress {
-        tracing::debug!("event was progress");
-
-        CoconutEventJob::Progress {
+    let job = match event {
+        CoconutWebHook::OutputCompleted { progress, .. } => Some(CoconutEventJob::Progress {
             display_name,
-            progress: progress.to_string(),
+            progress,
+        }),
+        CoconutWebHook::JobCompleted { outputs, .. } => {
+            let thumb_url = outputs
+                .iter()
+                .find_map(|output| match &output.status {
+                    CoconutOutputStatus::ImageCreated {
+                        file: CoconutOutputFile::Image { urls },
+                    } => urls.first(),
+                    _ => None,
+                })
+                .ok_or_else(|| actix_web::error::ErrorBadRequest("missing thumbnail"))?
+                .to_owned();
+
+            let mut video_formats: HashMap<String, (String, String)> = outputs
+                .into_iter()
+                .filter_map(|output| match output.status {
+                    CoconutOutputStatus::VideoEncoded {
+                        file: CoconutOutputFile::Video { url, metadata },
+                    } => Some((output.key, (url, metadata.format.size))),
+                    _ => None,
+                })
+                .collect();
+
+            let mut url = None;
+
+            for format in COCONUT_FORMATS {
+                if let Some(data) = video_formats.remove(*format) {
+                    url = Some(data);
+                    break;
+                }
+            }
+
+            let (video_url, video_size) =
+                url.ok_or_else(|| actix_web::error::ErrorBadRequest("no known video formats"))?;
+
+            let video_size = video_size.parse().unwrap_or(i32::MAX);
+
+            Some(CoconutEventJob::Completed {
+                display_name,
+                thumb_url,
+                video_url,
+                video_size,
+            })
         }
-    } else if let Some(output_urls) = &data.output_urls {
-        tracing::debug!("event was output");
-
-        let thumb_url = output_urls
-            .thumbnail
-            .first()
-            .ok_or_else(|| actix_web::error::ErrorBadRequest("missing thumbnail"))?
-            .to_owned();
-
-        let video_url = if let Some(url) = &output_urls.video_720p {
-            url
-        } else if let Some(url) = &output_urls.video_480p {
-            url
-        } else if let Some(url) = &output_urls.video_360p {
-            url
-        } else {
-            return Err(actix_web::error::ErrorBadRequest(
-                "all output formats empty",
-            ));
-        };
-
-        CoconutEventJob::Completed {
-            display_name,
-            thumb_url,
-            video_url: video_url.to_owned(),
-        }
-    } else {
-        return Err(actix_web::error::ErrorBadRequest(
-            "no progress and no output urls",
-        ));
+        CoconutWebHook::InputTransferred => None,
     };
 
     tracing::info!("computed event: {:?}", job);
 
-    let job_id = faktory
-        .enqueue_job(job, None)
-        .await
-        .map_err(actix_web::error::ErrorBadRequest)?;
+    if let Some(job) = job {
+        let job_id = faktory
+            .enqueue_job(job, None)
+            .await
+            .map_err(actix_web::error::ErrorBadRequest)?;
 
-    tracing::trace!(%job_id, "enqueued video event");
+        tracing::trace!(%job_id, "enqueued video event");
+    } else {
+        tracing::debug!("event was not actionable");
+    }
 
     Ok(HttpResponse::Ok().body("OK"))
 }


### PR DESCRIPTION
Currently, videos are limited to relatively small resolutions and lengths due to limitations of inline query results. This works around the limit by offering users an option to be directly sent a larger video file which can be forwarded to chats. Additionally, it supports the newer v2 Coconut API.