### PR TITLE
Twitter images to default

### DIFF
--- a/src/execute/telegram/handlers/error_reply.rs
+++ b/src/execute/telegram/handlers/error_reply.rs
@@ -123,6 +123,8 @@ mod tests {
             length: 36,
             url: None,
             user: None,
+            language: None,
+            custom_emoji_id: None,
         }];
         let text = "e52569fa-99a0-44fc-ae9d-2477177b550b";
 

--- a/src/sites/mod.rs
+++ b/src/sites/mod.rs
@@ -785,7 +785,7 @@ impl Site for Twitter {
                     }),
                     None => Some(PostInfo {
                         file_type: get_file_ext(&item.media_url_https)?.to_owned(),
-                        url: item.media_url_https.clone(),
+                        url: format!("{}:orig", item.media_url_https),
                         thumb: Some(format!("{}:thumb", item.media_url_https)),
                         source_link: Some(item.expanded_url),
                         personal: user.protected,

--- a/src/sites/mod.rs
+++ b/src/sites/mod.rs
@@ -773,7 +773,7 @@ impl Site for Twitter {
                     Some(video_url) => Some(PostInfo {
                         file_type: get_file_ext(video_url)?.to_owned(),
                         url: video_url.to_string(),
-                        thumb: Some(format!("{}:thumb", item.media_url_https.clone())),
+                        thumb: Some(format!("{}:thumb", item.media_url_https)),
                         source_link: Some(item.expanded_url),
                         personal: user.protected,
                         title: Some(user.screen_name.clone()),
@@ -786,7 +786,7 @@ impl Site for Twitter {
                     None => Some(PostInfo {
                         file_type: get_file_ext(&item.media_url_https)?.to_owned(),
                         url: item.media_url_https.clone(),
-                        thumb: Some(format!("{}:thumb", item.media_url_https.clone())),
+                        thumb: Some(format!("{}:thumb", item.media_url_https)),
                         source_link: Some(item.expanded_url),
                         personal: user.protected,
                         site_name: self.name().into(),


### PR DESCRIPTION
By default Twitter presents images at "medium" size, but it is possible to obtain a higher quality "original" with the `:orig` name.

Note: Twitter will resize the image at upload time so that no one edge is greater than 4096 px.

It looks like Syfaro/tgbotapi-rs@3bdfa356c51aca7feeccb84e6df520479d9b78fd caused one of the unit tests to start failing, so committed a fix.